### PR TITLE
Only load istanbul plugin on test

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,9 @@
 {
   "presets": ["@babel/preset-flow", "@babel/preset-env"],
-  "plugins": ["@babel/plugin-proposal-class-properties", "@babel/plugin-transform-runtime", "istanbul"]
+  "plugins": ["@babel/plugin-proposal-class-properties", "@babel/plugin-transform-runtime"],
+  "env": {
+    "test": {
+      "plugins": ["istanbul"]
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "clean": "rimraf lib/*",
     "prepublish": "npm run build && npm run flow check",
     "flow": "flow",
-    "test": "npm run build && nyc --check-coverage --lines 90 mocha --require @babel/register ./test/**/*.spec.js"
+    "test": "npm run build && cross-env NODE_ENV=test nyc --check-coverage --lines 90 mocha --require @babel/register ./test/**/*.spec.js"
   },
   "precommit": "test",
   "author": "Joseph Lewkovich",
@@ -30,6 +30,7 @@
     "babel-plugin-istanbul": "^5.1.1",
     "babel-preset-minify": "^0.5.0",
     "chai": "^4.2.0",
+    "cross-env": "^5.2.0",
     "flow-bin": "^0.91.0",
     "mocha": "^5.2.0",
     "nyc": "^13.1.0",


### PR DESCRIPTION
Hi - noticed your issue in our Observable tracker, and wanted to follow up. This PR does something related to your question - it only loads the `istanbul` babel plugin when tests run. This is important because right now istanbul runs _always_, which means that the distributed package has coverage instrumentation, including [your user paths](https://unpkg.com/fas-js@1.0.3/lib/modules.js), embedded. Running the plugin only on tests cleans up the dist.

In terms of _loading it_, the difference is that RunKit is a Node.js environment, so this module, which is written with CommonJS require() and module.exports, will work like it does in Node. Observable is a browser environment, so it supports ES Modules (import and export), and UMD bundles (produced by tools like rollup, microbundle, webpack, parcel, etc). To require fas-js in Observable without producing a bundle like one of those, I'd recommend running:

```js
fas = require('https://bundle.run/fas-js@1.0.3')
```

bundle.run is a service that runs browserify and rollup on the fly for you.