### PR TITLE
docs: record Phase 2 audit issue numbers (#214-#226)

### DIFF
--- a/.github/issue-bodies/00-parent-epic.md
+++ b/.github/issue-bodies/00-parent-epic.md
@@ -1,0 +1,20 @@
+### Epic description
+
+Audit and plan the v1.1 prep modernization of fas-js: dependencies, build outputs, TypeScript migration, test stack, coverage policy, security remediation, demo port, and release runbook. No implementation in this epic — only scoped child issues that Phase 3 executes.
+
+All implementation PRs target `main-v1-1-prep`.
+
+### Task list
+
+- [ ] Dependency audit (#214)
+- [ ] Dependabot strategy (#215)
+- [ ] Build target spec (#216)
+- [ ] TypeScript migration plan (#217)
+- [ ] Test runner decision (#218)
+- [ ] Coverage policy — 100% (#219)
+- [ ] Windows dev support (#220)
+- [ ] API contract tests (#221)
+- [ ] Security remediation (#222)
+- [ ] Demo migration (#223)
+- [ ] README modernization (#224)
+- [ ] master → main rename runbook (#225)

--- a/.github/issue-bodies/01-dependency-audit.md
+++ b/.github/issue-bodies/01-dependency-audit.md
@@ -1,0 +1,12 @@
+Audit every entry in `package.json` and classify as production runtime, build-only, or test-only.
+
+**Deliverables:**
+- Table of current deps with version, purpose, and keep/remove/replace recommendation
+- Decision on whether `chalk`, `core-js`, `@babel/runtime`, `regenerator-runtime` belong in the published bundle
+- List of deps safe to remove after TypeScript + modern bundler migration
+
+**Acceptance criteria:**
+- [ ] Written audit attached to this issue or linked doc
+- [ ] No code changes required in this issue
+
+Relates to v1.1 prep on branch `main-v1-1-prep`.

--- a/.github/issue-bodies/02-dependabot.md
+++ b/.github/issue-bodies/02-dependabot.md
@@ -1,0 +1,6 @@
+`dependabot.yml` currently ignores most meaningful upgrades, freezing a 2019-era stack. Design a replacement strategy for `main-v1-1-prep`.
+
+**Deliverables:**
+- Which ignores to remove and in what order (grouped PRs)
+- Grouping rules for Babel, Mocha, Browserify successors
+- Policy for security-only bumps vs full toolchain upgrades

--- a/.github/issue-bodies/03-build-spec.md
+++ b/.github/issue-bodies/03-build-spec.md
@@ -1,0 +1,10 @@
+Define the target `package.json` `main` / `module` / `exports` fields and build artifacts for v1.1.
+
+**Constraints:**
+- `lib/bundle.js` UMD must continue working for jsDelivr CDN users (`fasJs` global)
+- npm consumers may get ESM + CJS dual package
+
+**Deliverables:**
+- Proposed `package.json` exports map
+- Bundler choice (`tsup`, `rollup`, or other) with rationale
+- Migration steps from Browserify + Babelify + tinyify

--- a/.github/issue-bodies/04-typescript.md
+++ b/.github/issue-bodies/04-typescript.md
@@ -1,0 +1,7 @@
+Plan migration of `src/**/*.js` (Flow) to TypeScript.
+
+**Deliverables:**
+- File-by-file migration order
+- `tsconfig.json` strictness level
+- Interim period strategy (if any)
+- Public API type definitions for `createFSA`, `simulateFSA`, `stepOnceFSA`

--- a/.github/issue-bodies/05-test-runner.md
+++ b/.github/issue-bodies/05-test-runner.md
@@ -1,0 +1,10 @@
+Evaluate test runner options for v1.1 prep.
+
+**Options:**
+- Upgrade Mocha + Chai + nyc in place
+- Migrate to Node built-in `node --test` (used in newer workspace repos)
+
+**Deliverables:**
+- Recommendation with pros/cons
+- Migration plan for existing `test/**/*.spec.js` files
+- Coverage tool choice (nyc, c8, or built-in)

--- a/.github/issue-bodies/06-coverage.md
+++ b/.github/issue-bodies/06-coverage.md
@@ -1,0 +1,6 @@
+Define the coverage gate for `main-v1-1-prep`: **100% line coverage** with exceptions only for genuinely complex edge cases.
+
+**Deliverables:**
+- nyc/c8 threshold config change plan (90 → 100)
+- Exception process: inline comment + linked issue required
+- Inventory of current uncovered lines in `src/`

--- a/.github/issue-bodies/07-windows.md
+++ b/.github/issue-bodies/07-windows.md
@@ -1,0 +1,11 @@
+On Windows (Node 22), `npm test` fails after build:
+
+```
+Error: Cannot find module '...\node'
+```
+
+Reproduction: `npm ci && npm test` on Windows 10/11.
+
+**Deliverables:**
+- Root cause identified (cross-env, nyc, mocha arg parsing)
+- Fix verified on Windows and Linux CI

--- a/.github/issue-bodies/08-api-contracts.md
+++ b/.github/issue-bodies/08-api-contracts.md
@@ -1,0 +1,9 @@
+Add golden/contract tests for the public API before any modernization PRs land:
+
+- `createFSA(Q, Σ, δ, q0, F)` — DFA and NFA creation, validation errors
+- `simulateFSA(w, fsa, ...)` — acceptance, rejection, `returnEndState`
+- `stepOnceFSA(w, qin, fsa, ...)` — single-step transitions
+
+**Deliverables:**
+- Contract test file(s) that must pass on every Phase 3 PR
+- Documented breaking-change process (major version only)

--- a/.github/issue-bodies/09-security.md
+++ b/.github/issue-bodies/09-security.md
@@ -1,0 +1,6 @@
+`npm audit` reports 45 vulnerabilities (11 critical) on current lockfile. Inventory and plan remediation without uncontrolled breaking changes.
+
+**Deliverables:**
+- Categorized findings: fix now / fix with toolchain upgrade / accepted risk
+- Ordered remediation PR plan
+- Whether `npm audit --audit-level=high` in CI should fail (currently `continue-on-error`)

--- a/.github/issue-bodies/10-demo.md
+++ b/.github/issue-bodies/10-demo.md
@@ -1,0 +1,12 @@
+The interactive FSA demo lives on [ObservableHQ](https://beta.observablehq.com/@jml6m/state-machine-simulator). Plan porting to a better host and building a v1.1 demo.
+
+**Requirements:**
+- Keep v1 demo accessible for legacy users
+- v1.1 demo uses modernized library build
+- Document hosting choice (GitHub Pages, separate repo, or in-repo `demo/`)
+
+**Sub-tasks (create as separate issues):**
+- [ ] Evaluate hosting options
+- [ ] Port UI (preact + d3 + d3-graphviz)
+- [ ] Wire to v1.1 bundle
+- [ ] Update README demo links

--- a/.github/issue-bodies/11-readme.md
+++ b/.github/issue-bodies/11-readme.md
@@ -1,0 +1,7 @@
+Plan README changes for v1.1 release:
+
+- ESM / CJS import examples alongside UMD CDN snippet
+- Branch policy pointer to CONTRIBUTING.md
+- Updated badges after `master` → `main` rename
+- Demo links (v1 legacy + v1.1)
+- Fix known typo (`nfa_tfunc = =`)

--- a/.github/issue-bodies/12-rename-runbook.md
+++ b/.github/issue-bodies/12-rename-runbook.md
@@ -1,0 +1,11 @@
+Document the steps for v1.1 release:
+
+1. Final PR `main-v1-1-prep` → `master`
+2. Rename default branch `master` → `main` on GitHub
+3. Update CI badge URLs, Codecov default branch, README links
+4. Human version bump + `v*.*.*` tag
+5. `publish.yml` OIDC publish (upgrade workflow if needed)
+
+**Deliverables:**
+- Checklist with owner (human vs agent) per step
+- List of all URLs/refs that mention `master`

--- a/.github/phase2-audit-issue-drafts.md
+++ b/.github/phase2-audit-issue-drafts.md
@@ -19,18 +19,20 @@ Audit and plan the v1.1 prep modernization of fas-js: dependencies, build output
 
 ### Task list
 
-- [ ] Dependency audit (#TBD)
-- [ ] Dependabot strategy (#TBD)
-- [ ] Build target spec (#TBD)
-- [ ] TypeScript migration plan (#TBD)
-- [ ] Test runner decision (#TBD)
-- [ ] Coverage policy — 100% (#TBD)
-- [ ] Windows dev support (#TBD)
-- [ ] API contract tests (#TBD)
-- [ ] Security remediation (#TBD)
-- [ ] Demo migration (#TBD)
-- [ ] README modernization (#TBD)
-- [ ] master → main rename runbook (#TBD)
+- [x] Dependency audit (#214)
+- [x] Dependabot strategy (#215)
+- [x] Build target spec (#216)
+- [x] TypeScript migration plan (#217)
+- [x] Test runner decision (#218)
+- [x] Coverage policy — 100% (#219)
+- [x] Windows dev support (#220)
+- [x] API contract tests (#221)
+- [x] Security remediation (#222)
+- [x] Demo migration (#223)
+- [x] README modernization (#224)
+- [x] master → main rename runbook (#225)
+
+**Parent epic:** #226
 
 ---
 


### PR DESCRIPTION
Closes #214

Records the GitHub issue numbers created for the v1.1 prep audit epic and preserves issue body templates under \.github/issue-bodies/\.