### PR TITLE
fix: correct github-script action SHA in auto-link workflow

### DIFF
--- a/.github/workflows/auto-link-issue.yml
+++ b/.github/workflows/auto-link-issue.yml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/github-script@ed597411d8f32433762f32dcba8c78b66b8149a0 # v8.0.0
+      - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             const headRepo = context.payload.pull_request.head.repo.full_name;


### PR DESCRIPTION
Fixes auto-link workflow failure caused by an invalid actions/github-script pin.