### PR TITLE
feat: complete v1.1 prep Phase 2 audits, demo, and docs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,43 +11,20 @@ updates:
           - "@babel/*"
           - "babelify"
           - "babel-*"
+      testing:
+        patterns:
+          - "mocha"
+          - "chai"
+          - "nyc"
+          - "c8"
     ignore:
-      - dependency-name: babel-plugin-istanbul
-        versions:
-          - "> 5.2.0"
-      - dependency-name: "@babel/preset-flow"
-        versions:
-          - "> 7.0.0"
-      - dependency-name: "@babel/register"
-        versions:
-          - "> 7.6.0"
-      - dependency-name: "@babel/runtime"
-        versions:
-          - "> 7.6.0"
-      - dependency-name: chalk
-        versions:
-          - "> 2.4.2"
-      - dependency-name: cross-env
-        versions:
-          - "> 6.0.0"
-      - dependency-name: cross-env
-        versions:
-          - "> 6.0.0, < 6.1"
+      # Flow frozen until TypeScript migration (Phase 3)
       - dependency-name: flow-bin
         versions:
           - "> 0.107.0"
-      - dependency-name: mocha
+      - dependency-name: "@babel/preset-flow"
         versions:
-          - "> 6.2.0, < 6.3"
-      - dependency-name: rimraf
-        versions:
-          - "> 3.0.0"
-      - dependency-name: lodash
-        versions:
-          - 4.17.20
-      - dependency-name: elliptic
-        versions:
-          - 6.5.3
+          - "> 7.0.0"
 
   - package-ecosystem: github-actions
     directory: "/"

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,55 @@
+name: Deploy demo to GitHub Pages
+
+on:
+  push:
+    branches: [main-v1-1-prep]
+    paths:
+      - "demo/**"
+      - "src/**"
+      - "package.json"
+      - "package-lock.json"
+      - ".github/workflows/pages.yml"
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+      - run: npm run build
+
+      - name: Copy browser bundle into demo vendor folder
+        run: |
+          mkdir -p demo/v1.1/vendor
+          cp lib/bundle.js demo/v1.1/vendor/fas-js.bundle.js
+
+      - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
+
+      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
+        with:
+          path: demo/v1.1
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
+        id: deployment

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 lib/*
 !lib/.gitkeep
+demo/v1.1/vendor/fas-js.bundle.js
 node_modules/
 coverage/

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 
 Easily create and simulate state machines using this JS library. Import into your own server side or browser based JS application.
 
+> **Contributing / v1.1 prep:** Development happens on [`main-v1-1-prep`](https://github.com/jml6m/fas-js/tree/main-v1-1-prep). See [CONTRIBUTING.md](CONTRIBUTING.md) and [docs/v1.1-prep/](docs/v1.1-prep/).
+
 ![FSA Example](img/fsa_example.png)
 ###### Visualization of an FSA
 
@@ -74,7 +76,7 @@ const dfa_tfunc = [
     { from: "q1", to: "q1", input: "0" }
 ];
 
-const nfa_tfunc = = [
+const nfa_tfunc = [
     { from: "q1", to: "q1", input: "0" },
     { from: "q1", to: "q1,q2", input: "1" },
     { from: "q2", to: "q3", input: "0" },
@@ -156,9 +158,15 @@ else
 ```
 
 ## Demo
-This library provides an engine that creates and simulates an FSA. The demo below provides a UI that utilizes this engine and visualizes the FSA as it's being processed. It's a great way to learn about FSAs and experiment with your own FSA creations! The UI and graph visualizations were built using [preact](https://github.com/developit/preact), [d3.js](https://github.com/d3/d3), and [d3-graphviz](https://github.com/magjac/d3-graphviz).
 
-[Demo on ObservableHQ](https://beta.observablehq.com/@jml6m/state-machine-simulator) (Learn more about ObservableHQ [here](https://beta.observablehq.com/collection/@observablehq/introduction))
+Interactive demos visualize FSAs as you simulate input strings.
+
+| Version | URL | Notes |
+|---------|-----|-------|
+| **v1.1** (prep) | [GitHub Pages demo](https://jml6m.github.io/fas-js/demo/v1.1/) | Self-hosted in this repo (`demo/v1.1/`); uses current `fasJs` bundle |
+| **v1** (legacy) | [ObservableHQ](https://observablehq.com/@jml6m/state-machine-simulator) | Original demo; kept for legacy reference |
+
+See [demo/README.md](demo/README.md) for local development and deployment details.
 
 ## License
 This library is distributed under the GPL 3.0 license found in the [LICENSE](https://github.com/jml6m/fas-js/blob/master/LICENSE) file.

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,0 +1,57 @@
+# fas-js Demo
+
+This folder contains two versions of the finite state automaton simulator UI.
+
+## Versions
+
+| Path | Description | URL |
+|------|-------------|-----|
+| `v1/` | Legacy redirect page pointing to the original [ObservableHQ notebook](https://observablehq.com/@jml6m/state-machine-simulator) | Local file only |
+| `v1.1/` | Self-hosted, vanilla JS demo using the `fas-js` browser bundle | https://jml6m.github.io/fas-js/demo/v1.1/ |
+
+### v1 — Observable (legacy)
+
+The first public demo was published as an Observable notebook. The `v1/index.html` page explains that history and redirects visitors to the notebook.
+
+### v1.1 — Self-hosted (current)
+
+The v1.1 demo is a static site with no npm build step of its own. It loads:
+
+- `fasJs` from `./vendor/fas-js.bundle.js` (copied from `lib/bundle.js` during CI deploy)
+- [D3](https://d3js.org/), [@hpcc-js/wasm](https://github.com/hpcc-systems/hpcc-js-wasm), and [d3-graphviz](https://github.com/magjac/d3-graphviz) from CDN for graph rendering
+
+Features:
+
+- Pre-loaded binary DFA from the README example (accepts strings ending in `1`)
+- Full simulation via `simulateFSA()`
+- Step-through mode via `stepOnceFSA()`
+- Graph visualization via `fsa.generateDigraph()`
+
+## Local development
+
+The demo does not commit `vendor/fas-js.bundle.js`. Build the library and copy the bundle before opening the page locally:
+
+```bash
+npm ci
+npm run build
+mkdir -p demo/v1.1/vendor
+cp lib/bundle.js demo/v1.1/vendor/fas-js.bundle.js
+```
+
+Then serve `demo/v1.1/` with any static file server, for example:
+
+```bash
+npx --yes serve demo/v1.1
+```
+
+## Deployment
+
+GitHub Pages deployment is handled by [`.github/workflows/pages.yml`](../.github/workflows/pages.yml) on pushes to `main-v1-1-prep` when `demo/**`, `src/**`, or `package.json` change.
+
+The workflow:
+
+1. Runs `npm ci && npm run build`
+2. Copies `lib/bundle.js` to `demo/v1.1/vendor/fas-js.bundle.js`
+3. Publishes the `demo/v1.1/` directory to GitHub Pages
+
+Public URL: **https://jml6m.github.io/fas-js/demo/v1.1/**

--- a/demo/v1.1/app.js
+++ b/demo/v1.1/app.js
@@ -1,0 +1,228 @@
+/* global fasJs, d3 */
+
+(function () {
+  "use strict";
+
+  const { createFSA, simulateFSA, stepOnceFSA } = fasJs;
+
+  const EXAMPLE = {
+    states: ["q1", "q2"],
+    alphabet: "01",
+    transitions: [
+      { from: "q1", to: "q2", input: "1" },
+      { from: "q2", to: "q1", input: "0" },
+      { from: "q2", to: "q2", input: "1" },
+      { from: "q1", to: "q1", input: "0" },
+    ],
+    start: "q1",
+    accepts: ["q2"],
+  };
+
+  const fsa = createFSA(
+    EXAMPLE.states,
+    EXAMPLE.alphabet,
+    EXAMPLE.transitions,
+    EXAMPLE.start,
+    EXAMPLE.accepts
+  );
+
+  const inputEl = document.getElementById("input-string");
+  const simulateBtn = document.getElementById("simulate-btn");
+  const resetBtn = document.getElementById("reset-btn");
+  const stepBtn = document.getElementById("step-btn");
+  const stepResetBtn = document.getElementById("step-reset-btn");
+  const currentStateEl = document.getElementById("current-state");
+  const nextSymbolEl = document.getElementById("next-symbol");
+  const positionEl = document.getElementById("position");
+  const resultEl = document.getElementById("result");
+  const fsaTypeEl = document.getElementById("fsa-type");
+  const graphEl = document.getElementById("graph");
+
+  let graphviz = null;
+  let stepSession = null;
+
+  function escapeRegExp(value) {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  }
+
+  function highlightStateInDot(dot, stateName) {
+    if (!stateName) {
+      return dot;
+    }
+
+    const escaped = escapeRegExp(stateName);
+    const pattern = new RegExp(
+      `(^|\\n)(\\s*)(${escaped})(\\s*\\[shape = doublecircle\\])?(;)?`,
+      "m"
+    );
+
+    return dot.replace(
+      pattern,
+      '$1$2$3 [style=filled, fillcolor="#fef08a"$4];'
+    );
+  }
+
+  function renderGraph(highlightState) {
+    const dot = highlightStateInDot(fsa.generateDigraph(), highlightState);
+
+    if (!graphviz) {
+      graphviz = d3.select(graphEl).graphviz().zoom(false);
+    }
+
+    graphviz.renderDot(dot);
+  }
+
+  function formatState(state) {
+    return Array.isArray(state) ? state.join(", ") : state;
+  }
+
+  function isAccepted(endState) {
+    if (Array.isArray(endState)) {
+      return endState.some((state) => EXAMPLE.accepts.includes(state));
+    }
+    return EXAMPLE.accepts.includes(endState);
+  }
+
+  function setResult(message, tone) {
+    resultEl.textContent = message;
+    resultEl.className = "result";
+    if (tone) {
+      resultEl.classList.add("result--" + tone);
+    }
+  }
+
+  function updateStepDisplay(session) {
+    const input = session.input;
+    const position = session.position;
+
+    currentStateEl.textContent = formatState(session.currentState);
+    nextSymbolEl.textContent =
+      position < input.length ? input.charAt(position) : "(none)";
+    positionEl.textContent = position + " / " + input.length;
+    renderGraph(formatState(session.currentState));
+  }
+
+  function createStepSession(input) {
+    return {
+      input: input,
+      currentState: EXAMPLE.start,
+      position: 0,
+    };
+  }
+
+  function readInput() {
+    return inputEl.value.trim();
+  }
+
+  function handleSimulate() {
+    const input = readInput();
+
+    try {
+      const accepted = simulateFSA(input, fsa);
+      const endState = simulateFSA(input, fsa, false, true);
+      const tone = accepted ? "accept" : "reject";
+
+      setResult(
+        (accepted ? "Accepted" : "Rejected") +
+          " — final state: " +
+          formatState(endState),
+        tone
+      );
+
+      stepSession = createStepSession(input);
+      stepSession.currentState = endState;
+      stepSession.position = input.length;
+      updateStepDisplay(stepSession);
+    } catch (error) {
+      setResult("Simulation error: " + error.message, "error");
+    }
+  }
+
+  function handleStep() {
+    const input = readInput();
+
+    if (!stepSession || stepSession.input !== input) {
+      stepSession = createStepSession(input);
+      setResult("Step mode started. Press Step to consume the next symbol.", "idle");
+    }
+
+    if (stepSession.position >= stepSession.input.length) {
+      const accepted = isAccepted(stepSession.currentState);
+      setResult(
+        (accepted ? "Accepted" : "Rejected") +
+          " — finished at state " +
+          formatState(stepSession.currentState),
+        accepted ? "accept" : "reject"
+      );
+      return;
+    }
+
+    const symbol = stepSession.input.charAt(stepSession.position);
+
+    try {
+      stepSession.currentState = stepOnceFSA(
+        symbol,
+        stepSession.currentState,
+        fsa
+      );
+      stepSession.position += 1;
+      updateStepDisplay(stepSession);
+
+      if (stepSession.position >= stepSession.input.length) {
+        const accepted = isAccepted(stepSession.currentState);
+        setResult(
+          "Last symbol processed. " +
+            (accepted ? "Accepted" : "Rejected") +
+            " at state " +
+            formatState(stepSession.currentState),
+          accepted ? "accept" : "reject"
+        );
+      } else {
+        setResult(
+          'Processed "' +
+            symbol +
+            '". Now at state ' +
+            formatState(stepSession.currentState) +
+            ".",
+          "idle"
+        );
+      }
+    } catch (error) {
+      setResult("Step error: " + error.message, "error");
+    }
+  }
+
+  function handleReset() {
+    inputEl.value = "101";
+    stepSession = createStepSession(inputEl.value);
+    setResult("Enter an input string and press Simulate or Step.", "idle");
+    updateStepDisplay(stepSession);
+  }
+
+  function handleStepReset() {
+    stepSession = createStepSession(readInput());
+    setResult("Step mode restarted from the start state.", "idle");
+    updateStepDisplay(stepSession);
+  }
+
+  function init() {
+    fsaTypeEl.textContent = fsa.getType();
+    stepSession = createStepSession(inputEl.value);
+
+    simulateBtn.addEventListener("click", handleSimulate);
+    resetBtn.addEventListener("click", handleReset);
+    stepBtn.addEventListener("click", handleStep);
+    stepResetBtn.addEventListener("click", handleStepReset);
+
+    inputEl.addEventListener("keydown", function (event) {
+      if (event.key === "Enter") {
+        handleSimulate();
+      }
+    });
+
+    updateStepDisplay(stepSession);
+    setResult("Enter an input string and press Simulate or Step.", "idle");
+  }
+
+  init();
+})();

--- a/demo/v1.1/index.html
+++ b/demo/v1.1/index.html
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>FSA Simulator — fas-js v1.1</title>
+    <meta
+      name="description"
+      content="Interactive finite state automaton simulator powered by fas-js."
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <div class="app">
+      <header class="header">
+        <div class="header__text">
+          <p class="eyebrow">fas-js demo</p>
+          <h1>Finite State Automaton Simulator</h1>
+          <p class="subtitle">
+            Explore a pre-loaded binary DFA that accepts strings ending in
+            <code>1</code>. Run a full simulation or step through the input one
+            symbol at a time.
+          </p>
+        </div>
+        <div class="header__meta">
+          <span class="badge" id="fsa-type">DFA</span>
+          <a
+            class="link"
+            href="https://github.com/jml6m/fas-js"
+            target="_blank"
+            rel="noopener noreferrer"
+            >View on GitHub</a
+          >
+        </div>
+      </header>
+
+      <main class="layout">
+        <section class="panel controls" aria-labelledby="controls-heading">
+          <h2 id="controls-heading">Simulation</h2>
+
+          <label class="field" for="input-string">
+            <span class="field__label">Input string</span>
+            <input
+              id="input-string"
+              type="text"
+              value="101"
+              placeholder="Enter symbols from alphabet 01"
+              autocomplete="off"
+              spellcheck="false"
+            />
+          </label>
+
+          <div class="button-row">
+            <button id="simulate-btn" type="button" class="btn btn--primary">
+              Simulate
+            </button>
+            <button id="reset-btn" type="button" class="btn btn--ghost">
+              Reset
+            </button>
+          </div>
+
+          <div class="mode-divider" role="separator" aria-hidden="true"></div>
+
+          <h3 class="section-title">Step-through mode</h3>
+          <p class="hint">
+            Process the input symbol by symbol. The graph highlights the current
+            state after each step.
+          </p>
+
+          <div class="button-row">
+            <button id="step-btn" type="button" class="btn">Step</button>
+            <button id="step-reset-btn" type="button" class="btn btn--ghost">
+              Restart steps
+            </button>
+          </div>
+
+          <dl class="status-grid">
+            <div>
+              <dt>Current state</dt>
+              <dd id="current-state">q1</dd>
+            </div>
+            <div>
+              <dt>Next symbol</dt>
+              <dd id="next-symbol">1</dd>
+            </div>
+            <div>
+              <dt>Position</dt>
+              <dd id="position">0 / 3</dd>
+            </div>
+          </dl>
+
+          <div id="result" class="result result--idle" role="status" aria-live="polite">
+            Enter an input string and press Simulate or Step.
+          </div>
+        </section>
+
+        <section class="panel graph-panel" aria-labelledby="graph-heading">
+          <h2 id="graph-heading">State machine graph</h2>
+          <div id="graph" class="graph" aria-label="FSA graph visualization"></div>
+          <p class="footnote">
+            Graph rendered from <code>fsa.generateDigraph()</code> using D3 and
+            d3-graphviz.
+          </p>
+        </section>
+      </main>
+
+      <footer class="footer">
+        <p>
+          Self-hosted demo for
+          <a href="https://github.com/jml6m/fas-js">fas-js</a>. Legacy Observable
+          notebook:
+          <a href="../v1/index.html">v1 redirect</a>.
+        </p>
+      </footer>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/d3@7.9.0/dist/d3.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@hpcc-js/wasm@2.16.2/dist/index.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/d3-graphviz@5.6.0/build/d3-graphviz.min.js"></script>
+    <script src="./vendor/fas-js.bundle.js"></script>
+    <script src="./app.js"></script>
+  </body>
+</html>

--- a/demo/v1.1/styles.css
+++ b/demo/v1.1/styles.css
@@ -1,0 +1,326 @@
+:root {
+  color-scheme: light;
+  --bg: #f4f7fb;
+  --surface: #ffffff;
+  --text: #0f172a;
+  --muted: #64748b;
+  --border: #dbe3ef;
+  --primary: #2563eb;
+  --primary-hover: #1d4ed8;
+  --accept: #166534;
+  --accept-bg: #dcfce7;
+  --reject: #b91c1c;
+  --reject-bg: #fee2e2;
+  --error: #9a3412;
+  --error-bg: #ffedd5;
+  --shadow: 0 18px 40px rgba(15, 23, 42, 0.08);
+  --radius: 18px;
+  --font: "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  --mono: "Cascadia Code", "SFMono-Regular", Consolas, monospace;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: var(--font);
+  color: var(--text);
+  background:
+    radial-gradient(circle at top left, rgba(37, 99, 235, 0.12), transparent 28%),
+    linear-gradient(180deg, #eef4ff 0%, var(--bg) 45%, #f8fafc 100%);
+}
+
+code {
+  font-family: var(--mono);
+  font-size: 0.92em;
+  background: #eef2ff;
+  padding: 0.12rem 0.35rem;
+  border-radius: 0.35rem;
+}
+
+.app {
+  width: min(1180px, calc(100% - 2rem));
+  margin: 0 auto;
+  padding: 2rem 0 3rem;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1.5rem;
+  align-items: flex-start;
+  margin-bottom: 1.5rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  font-size: 0.82rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--primary);
+}
+
+.header h1 {
+  margin: 0 0 0.75rem;
+  font-size: clamp(1.9rem, 4vw, 2.6rem);
+  line-height: 1.1;
+}
+
+.subtitle {
+  margin: 0;
+  max-width: 52rem;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.header__meta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.75rem;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.35rem 0.7rem;
+  border-radius: 999px;
+  background: #dbeafe;
+  color: #1e3a8a;
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+
+.link {
+  color: var(--primary);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.link:hover {
+  text-decoration: underline;
+}
+
+.layout {
+  display: grid;
+  grid-template-columns: minmax(280px, 360px) minmax(0, 1fr);
+  gap: 1.25rem;
+}
+
+.panel {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  padding: 1.35rem;
+}
+
+.panel h2,
+.section-title {
+  margin: 0 0 1rem;
+  font-size: 1.1rem;
+}
+
+.section-title {
+  margin-top: 0;
+}
+
+.field {
+  display: grid;
+  gap: 0.45rem;
+  margin-bottom: 1rem;
+}
+
+.field__label {
+  font-size: 0.92rem;
+  font-weight: 600;
+}
+
+.field input {
+  width: 100%;
+  padding: 0.8rem 0.95rem;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  font: inherit;
+  background: #f8fafc;
+}
+
+.field input:focus {
+  outline: 2px solid rgba(37, 99, 235, 0.25);
+  border-color: var(--primary);
+  background: #fff;
+}
+
+.button-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+}
+
+.btn {
+  appearance: none;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: #fff;
+  color: var(--text);
+  padding: 0.72rem 1rem;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease, transform 0.15s ease;
+}
+
+.btn:hover {
+  background: #f8fafc;
+  border-color: #c7d2e3;
+}
+
+.btn:active {
+  transform: translateY(1px);
+}
+
+.btn--primary {
+  background: var(--primary);
+  border-color: var(--primary);
+  color: #fff;
+}
+
+.btn--primary:hover {
+  background: var(--primary-hover);
+  border-color: var(--primary-hover);
+}
+
+.btn--ghost {
+  background: transparent;
+}
+
+.mode-divider {
+  height: 1px;
+  background: var(--border);
+  margin: 1.25rem 0;
+}
+
+.hint {
+  margin: 0 0 1rem;
+  color: var(--muted);
+  font-size: 0.92rem;
+  line-height: 1.5;
+}
+
+.status-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.75rem;
+  margin: 1.1rem 0;
+}
+
+.status-grid dt {
+  margin: 0 0 0.2rem;
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--muted);
+}
+
+.status-grid dd {
+  margin: 0;
+  font-family: var(--mono);
+  font-size: 0.95rem;
+  font-weight: 700;
+}
+
+.result {
+  margin-top: 1rem;
+  padding: 0.9rem 1rem;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: #f8fafc;
+  line-height: 1.5;
+  min-height: 3.25rem;
+}
+
+.result--accept {
+  color: var(--accept);
+  background: var(--accept-bg);
+  border-color: #86efac;
+}
+
+.result--reject {
+  color: var(--reject);
+  background: var(--reject-bg);
+  border-color: #fca5a5;
+}
+
+.result--error {
+  color: var(--error);
+  background: var(--error-bg);
+  border-color: #fdba74;
+}
+
+.result--idle {
+  color: var(--muted);
+}
+
+.graph-panel {
+  min-height: 520px;
+  display: flex;
+  flex-direction: column;
+}
+
+.graph {
+  flex: 1;
+  min-height: 420px;
+  overflow: auto;
+  border: 1px dashed var(--border);
+  border-radius: 14px;
+  background: linear-gradient(180deg, #fbfdff 0%, #f8fafc 100%);
+  padding: 0.5rem;
+}
+
+.graph svg {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+.footnote {
+  margin: 0.85rem 0 0;
+  color: var(--muted);
+  font-size: 0.86rem;
+}
+
+.footer {
+  margin-top: 1.5rem;
+  color: var(--muted);
+  font-size: 0.92rem;
+}
+
+.footer a {
+  color: var(--primary);
+}
+
+@media (max-width: 900px) {
+  .header,
+  .layout {
+    grid-template-columns: 1fr;
+    display: grid;
+  }
+
+  .header {
+    gap: 1rem;
+  }
+
+  .header__meta {
+    align-items: flex-start;
+  }
+
+  .status-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/demo/v1/index.html
+++ b/demo/v1/index.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>FSA Simulator v1 — Legacy Redirect</title>
+    <meta http-equiv="refresh" content="3;url=https://observablehq.com/@jml6m/state-machine-simulator" />
+    <style>
+      :root {
+        color-scheme: light;
+        font-family: "Segoe UI", system-ui, sans-serif;
+        line-height: 1.6;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: grid;
+        place-items: center;
+        background: #f4f7fb;
+        color: #0f172a;
+      }
+
+      main {
+        width: min(640px, calc(100% - 2rem));
+        background: #fff;
+        border: 1px solid #dbe3ef;
+        border-radius: 18px;
+        padding: 2rem;
+        box-shadow: 0 18px 40px rgba(15, 23, 42, 0.08);
+      }
+
+      h1 {
+        margin-top: 0;
+      }
+
+      a {
+        color: #2563eb;
+        font-weight: 600;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>FSA Simulator v1 (Legacy)</h1>
+      <p>
+        The original interactive demo lived on ObservableHQ as a notebook built
+        with Preact, D3, and d3-graphviz. That version is preserved for reference
+        and learning material.
+      </p>
+      <p>
+        You will be redirected in a few seconds to:
+        <a href="https://observablehq.com/@jml6m/state-machine-simulator"
+          >https://observablehq.com/@jml6m/state-machine-simulator</a
+        >
+      </p>
+      <p>
+        For the self-hosted demo that ships with this repository, use
+        <a href="../v1.1/index.html">v1.1</a> instead.
+      </p>
+    </main>
+  </body>
+</html>

--- a/docs/v1.1-prep/PHASE3_READY.md
+++ b/docs/v1.1-prep/PHASE3_READY.md
@@ -1,0 +1,35 @@
+# Phase 3 Readiness Checklist
+
+Use this before starting the TypeScript + tsup modernization PR stack.
+
+## Completed in Phase 2 (this milestone)
+
+- [x] Governance: CONTRIBUTING, issue templates, PR template, branch rules
+- [x] Windows `npm test` fix (#220, nyc 17)
+- [x] API contract tests (#221)
+- [x] Audit docs: dependencies, dependabot, build spec, TS plan, test runner, coverage, security
+- [x] Demo v1.1 in-repo + GitHub Pages workflow (#223)
+- [x] README + demo links (#224)
+- [x] Release runbook (#225)
+
+## Phase 3 PR stack (recommended order)
+
+1. **Test stack** — Mocha 10 + c8, raise coverage to 100%
+2. **TypeScript migration** — all `src/` → `.ts`, remove Flow
+3. **tsup build** — ESM + CJS + UMD per [build-target-spec.md](./build-target-spec.md)
+4. **Dependency cleanup** — remove chalk/core-js/babel runtime from bundle
+5. **Security** — fail CI on high audit findings
+6. **pre-commit removal** — CI-only gates
+
+## Merge gate (every Phase 3 PR)
+
+```bash
+npm ci
+npm test
+# api-contract.spec.js included in test suite
+```
+
+## Human decisions deferred to Phase 3 start
+
+- Exact npm version number for v1.1 release (`1.4.0` vs `1.3.3`)
+- Whether to fail `npm audit` immediately or after toolchain PR

--- a/docs/v1.1-prep/build-target-spec.md
+++ b/docs/v1.1-prep/build-target-spec.md
@@ -1,0 +1,50 @@
+# Build Target Spec — ESM, CJS, UMD
+
+Closes [#216](https://github.com/jml6m/fas-js/issues/216).
+
+## Constraints
+
+- **UMD** `lib/bundle.js` with global `fasJs` must continue for jsDelivr CDN users.
+- npm consumers should get **ESM + CJS** dual package in v1.1 release.
+- Public API unchanged: `createFSA`, `simulateFSA`, `stepOnceFSA`.
+
+## Target `package.json` exports (Phase 3)
+
+```json
+{
+  "main": "./lib/index.cjs",
+  "module": "./lib/index.js",
+  "types": "./lib/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./lib/index.d.ts",
+      "import": "./lib/index.js",
+      "require": "./lib/index.cjs"
+    },
+    "./bundle": {
+      "default": "./lib/bundle.js"
+    }
+  },
+  "files": ["lib"]
+}
+```
+
+## Bundler choice: **tsup**
+
+| Criterion | tsup | rollup | browserify (current) |
+|-----------|------|--------|----------------------|
+| TypeScript native | Yes | Via plugin | No |
+| ESM + CJS + IIFE/UMD | Yes | Yes | UMD only |
+| Config complexity | Low | Medium | Medium + Babel |
+| Tree-shaking | Yes | Yes | Limited |
+
+**Recommendation:** `tsup` for Phase 3 — single config produces ESM, CJS, and UMD (`globalName: fasJs`).
+
+## Migration steps (Phase 3)
+
+1. Add `tsup.config.ts` with three outputs.
+2. Migrate `src/**/*.js` → `src/**/*.ts`; remove Flow.
+3. Update `npm run build` to `tsup`.
+4. Keep `lib/bundle.js` path stable for CDN.
+5. Update demo Pages workflow to copy new bundle output (path unchanged).
+6. Contract tests (#221) must pass throughout.

--- a/docs/v1.1-prep/coverage-policy.md
+++ b/docs/v1.1-prep/coverage-policy.md
@@ -1,0 +1,38 @@
+# Coverage Policy — 100% with Documented Exceptions
+
+Closes [#219](https://github.com/jml6m/fas-js/issues/219).
+
+## Targets
+
+| Branch | Line coverage gate |
+|--------|-------------------|
+| `master` | 90% (current nyc config) |
+| `main-v1-1-prep` | **100%** after Phase 3 test-stack PR |
+
+## Current inventory (pre-Phase 3, nyc 17)
+
+| Metric | Coverage |
+|--------|----------|
+| Lines | 99.69% (330/331) |
+| Statements | 99.74% (397/398) |
+| Branches | 98.38% (243/247) |
+| Functions | 100% (60/60) |
+
+**Gap:** 1 uncovered line + 4 uncovered branches in `src/`. Identify and cover during Phase 3, or document exception.
+
+## Exception process
+
+1. Must be a genuinely complex edge case (e.g. unreachable defensive branch).
+2. Inline comment: `// coverage:ignore-next-line — reason, see #NNN`
+3. Linked GitHub issue explaining why 100% is impractical.
+4. Reviewer approval required.
+
+## Phase 3 config change
+
+```json
+"c8": {
+  "check-coverage": true,
+  "lines": 100,
+  "include": ["src/**/*.ts"]
+}
+```

--- a/docs/v1.1-prep/dependabot-strategy.md
+++ b/docs/v1.1-prep/dependabot-strategy.md
@@ -1,0 +1,34 @@
+# Dependabot Strategy — fas-js v1.1 Prep
+
+Closes [#215](https://github.com/jml6m/fas-js/issues/215).
+
+## Problem
+
+`dependabot.yml` previously ignored nearly all meaningful upgrades, freezing a 2019-era stack and blocking security fixes.
+
+## v1.1 prep policy
+
+1. **GitHub Actions** — weekly grouped bumps (unchanged).
+2. **npm** — monthly grouped bumps; ignores removed except where noted below.
+3. **All npm PRs target `main-v1-1-prep`** via Dependabot branch naming; merge only when CI passes.
+4. **No auto-merge** — human or agent review required.
+
+## Remaining ignores (temporary)
+
+| Dependency | Reason | Remove when |
+|------------|--------|-------------|
+| `flow-bin` | Flow frozen until TS migration | Phase 3 TS PR merges |
+| `@babel/preset-flow` | Same | Phase 3 TS PR merges |
+
+## Removed ignores (effective this phase)
+
+All other previous ignores (mocha, rimraf, chalk, cross-env, babel runtime, lodash pin, elliptic pin) are lifted. Dependabot may open upgrade PRs; evaluate each against CI and the [security remediation plan](./security-remediation.md).
+
+## Grouping
+
+- **babel group** — keep until Babel removed in Phase 3
+- Consider adding **mocha group** and **types group** after test runner decision
+
+## Security-only fast path
+
+Critical `npm audit` findings should get dedicated issues (see #222) rather than blind `npm audit fix --force`.

--- a/docs/v1.1-prep/dependency-audit.md
+++ b/docs/v1.1-prep/dependency-audit.md
@@ -1,0 +1,38 @@
+# Dependency Audit — fas-js v1.1 Prep
+
+Closes [#214](https://github.com/jml6m/fas-js/issues/214).
+
+## Production dependencies (`dependencies`)
+
+| Package | Version | Purpose | v1.1 recommendation |
+|---------|---------|---------|---------------------|
+| `@babel/runtime` | 7.6.0 | Babel transpiled helpers in bundle | **Remove** after TypeScript + modern bundler (Phase 3) |
+| `chalk` | 2.4.2 | Console logging in simulators | **Move to devDependency** or remove; should not ship in published bundle |
+| `core-js` | 3.2.1 | `@babel/preset-env` polyfills via `useBuiltIns: usage` | **Remove** from prod; target Node 18+ and modern browsers in Phase 3 |
+| `regenerator-runtime` | 0.13.3 | Async generator support via Babel | **Remove** with preset-env change |
+
+**Published bundle today:** Browserify inlines chalk, core-js polyfills, and Babel helpers into `lib/bundle.js`. The npm `files` field only ships the bundle, but the bundle is larger than necessary.
+
+## Dev dependencies (build & test)
+
+| Package | Version | Purpose | v1.1 recommendation |
+|---------|---------|---------|---------------------|
+| `@babel/*` + `babelify` | 7.6.x | Transpile Flow → JS for Browserify | **Replace** with TypeScript + `tsup`/`rollup` (Phase 3) |
+| `browserify` + `tinyify` | 16.x / 2.x | UMD bundle | **Replace** with dual ESM/CJS/UMD build (Phase 3) |
+| `flow-bin` | 0.107.0 | Type checking | **Replace** with `typescript` (Phase 3) |
+| `mocha` + `chai` | 6.2 / 4.2 | Test runner | **Upgrade** to Mocha 10+ or migrate to `node --test` (Phase 3) |
+| `nyc` | 17.1.0 | Coverage (upgraded #220) | **Replace** with `c8` when migrating test stack |
+| `cross-env` | 6.0.0 | `NODE_ENV=test` for istanbul | **Keep** until test stack migration |
+| `pre-commit` | 1.2.2 | Local git hook | **Remove** in Phase 3; CI-only gates |
+| `rimraf` | 3.0.0 | Clean `lib/` | **Upgrade** to rimraf 5+ or use `node:fs` rm |
+
+## Safe to remove after Phase 3
+
+- Entire Babel + Flow + Browserify toolchain
+- `chalk`, `core-js`, `@babel/runtime`, `regenerator-runtime` from any published artifact
+- `pre-commit` package
+
+## Keep through v1.1 release
+
+- Current Browserify pipeline until TypeScript migration PR lands
+- `nyc` 17.x (Windows + Node 22 compatible)

--- a/docs/v1.1-prep/release-runbook.md
+++ b/docs/v1.1-prep/release-runbook.md
@@ -1,0 +1,37 @@
+# Release Runbook — master → main at v1.1
+
+Closes [#225](https://github.com/jml6m/fas-js/issues/225).
+
+## Pre-merge checklist
+
+- [ ] All Phase 3 PRs merged to `main-v1-1-prep`
+- [ ] `npm test` passes at 100% coverage (or documented exceptions)
+- [ ] API contract tests pass
+- [ ] Demo deployed: https://jml6m.github.io/fas-js/demo/v1.1/
+- [ ] README updated
+- [ ] Human reviews final PR
+
+## Release steps
+
+| Step | Owner | Action |
+|------|-------|--------|
+| 1 | Human | Open PR `main-v1-1-prep` → `master`; get approval |
+| 2 | Human | Squash/merge PR |
+| 3 | Human | Rename default branch `master` → `main` on GitHub |
+| 4 | Agent/Human | Update badge URLs in README (CI, Codecov) |
+| 5 | Human | Bump `version` in `package.json` (e.g. `1.4.0`) |
+| 6 | Human | `git tag v1.x.y && git push origin v1.x.y` on `main` |
+| 7 | CI | `publish.yml` OIDC publish to npm |
+| 8 | Human | Enable GitHub Pages from `main` if workflow branch ref needs update |
+
+## URLs/refs to update
+
+- README CI badge: `branch=main`
+- Codecov badge: `branch/main`
+- `AGENTS.md` / `CONTRIBUTING.md` branch references
+- `.github/workflows/ci.yml` push branches
+- `.github/workflows/pages.yml` trigger branch (may stay `main-v1-1-prep` until archived, or switch to `main`)
+
+## npm publish
+
+Existing workflow unchanged: tag `v*.*.*` on stable branch triggers OIDC trusted publishing with npm 11.5.1+.

--- a/docs/v1.1-prep/security-remediation.md
+++ b/docs/v1.1-prep/security-remediation.md
@@ -1,0 +1,26 @@
+# Security Remediation Plan
+
+Closes [#222](https://github.com/jml6m/fas-js/issues/222).
+
+## Current state (post nyc 17 upgrade)
+
+`npm audit` reports vulnerabilities in **transitive** dependencies of the legacy Browserify/Babel tree. Most are dev-only and do not ship in `lib/bundle.js`.
+
+## Categorization
+
+| Category | Action | Examples |
+|----------|--------|----------|
+| **Fix now** | Safe patch bumps via Dependabot | `debug`, `minimist` patches |
+| **Fix with toolchain upgrade** | Resolved by removing Browserify/Babel | `elliptic`, old `glob`, `browserify` tree |
+| **Accepted risk (dev-only)** | Document until Phase 3 | Nested audit findings in unused code paths |
+
+## CI policy recommendation
+
+Change `npm audit --audit-level=high` from `continue-on-error: true` to **fail** on `main-v1-1-prep` once Phase 3 toolchain lands. Keep `continue-on-error` on `master` until v1.1 merges.
+
+## Ordered remediation PRs (Phase 3)
+
+1. Toolchain swap (TypeScript + tsup) — eliminates largest transitive tree
+2. Regenerate `package-lock.json` with `npm ci` clean install
+3. Enable audit failure in CI on `main-v1-1-prep`
+4. Triage any remaining production-bundle findings separately

--- a/docs/v1.1-prep/test-runner-decision.md
+++ b/docs/v1.1-prep/test-runner-decision.md
@@ -1,0 +1,32 @@
+# Test Runner Decision
+
+Closes [#218](https://github.com/jml6m/fas-js/issues/218).
+
+## Options evaluated
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **Mocha 10 + Chai + nyc/c8** | Minimal test rewrite; familiar API | Extra deps; nyc being phased out |
+| **Node `node --test` + assert** | Zero test-runner dep; built-in | Rewrite 62 tests; Chai matchers lost |
+
+## Recommendation: **Mocha 10 + c8**
+
+Aligns with incremental migration:
+
+1. Phase 3a: Upgrade Mocha 6 → 10, keep Chai, swap nyc → c8
+2. Phase 3b (optional later): Migrate to `node --test` if desired
+
+`node --test` is attractive long-term but rewriting 5 spec files for marginal gain delays the TypeScript migration. Mocha 10 works with ESM/CJS and has stable Chai integration.
+
+## Coverage tool: **c8**
+
+- Native V8 coverage (faster, Node 18+)
+- Drop-in replacement for nyc CLI flags
+- Target: `--check-coverage --lines 100` on `main-v1-1-prep`
+
+## Migration plan
+
+1. Add `c8` devDependency; configure in `package.json` or `.c8rc.json`
+2. Update `npm test` script
+3. Verify Windows + Linux CI (regression for #220)
+4. Proceed with TypeScript migration

--- a/docs/v1.1-prep/typescript-migration-plan.md
+++ b/docs/v1.1-prep/typescript-migration-plan.md
@@ -1,0 +1,56 @@
+# TypeScript Migration Plan
+
+Closes [#217](https://github.com/jml6m/fas-js/issues/217).
+
+## Target
+
+- `strict: true` in `tsconfig.json`
+- Flow annotations removed from all `src/` files
+- Published `.d.ts` for public API
+
+## File migration order
+
+| Order | File(s) | Notes |
+|-------|---------|-------|
+| 1 | `src/globals/errors.js`, `globals.js` | No Flow complexity |
+| 2 | `src/components/*.js` | Core types |
+| 3 | `src/interfaces/FSA.js` | Interface → `export interface FSA` |
+| 4 | `src/automata/*.js` | DFA/NFA classes |
+| 5 | `src/utils/*.js` | Includes `createFSA` |
+| 6 | `src/engine/Simulators.js` | Public API |
+| 7 | `src/modules.js` | Re-export entry |
+
+## Public API types (target)
+
+```typescript
+export function createFSA(
+  states: string[],
+  alphabet: string | string[],
+  transitions: TransitionInput[],
+  start: string,
+  accepts: string[]
+): FSA;
+
+export function simulateFSA(
+  w: string | string[],
+  fsa: FSA,
+  logging?: boolean,
+  returnEndState?: boolean
+): boolean | string | string[];
+
+export function stepOnceFSA(
+  w: string,
+  qin: string | string[],
+  fsa: FSA,
+  logging?: boolean
+): string | string[];
+```
+
+## Interim strategy
+
+No half-Flow/half-TS period. Single PR (or stacked PRs) converts all `src/` at once; tests stay in JS with `@ts-check` optional until test migration.
+
+## Test impact
+
+- `@babel/register` replaced by `tsx` or compiled test run
+- Contract tests in `test/api-contract.spec.js` are the merge gate


### PR DESCRIPTION
Closes #214
Closes #215
Closes #216
Closes #217
Closes #218
Closes #219
Closes #222
Closes #223
Closes #224
Closes #225
Relates to #226

## Summary

Completes Phase 2 deliverables on \main-v1-1-prep\:

- **Audit docs** in \docs/v1.1-prep/\ (dependency, dependabot, build spec, TypeScript plan, test runner, coverage, security, release runbook)
- **Phase 3 readiness** checklist at \docs/v1.1-prep/PHASE3_READY.md\
- **Demo v1.1** at \demo/v1.1/\ — self-hosted FSA simulator with d3-graphviz
- **Legacy v1** redirect at \demo/v1/\ → ObservableHQ
- **GitHub Pages** workflow deploys to https://jml6m.github.io/fas-js/demo/v1.1/
- **Dependabot** — lift blanket ignores (keep Flow frozen until Phase 3)
- **README** — contributing pointer, demo table, typo fix

## Public demo URL

https://jml6m.github.io/fas-js/demo/v1.1/ (after Pages workflow runs post-merge)