### PR TITLE
fix: GitHub Pages deploy paths and public demo URLs

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -42,7 +42,7 @@ jobs:
 
       - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
-          path: demo/v1.1
+          path: demo
 
   deploy:
     environment:

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Interactive demos visualize FSAs as you simulate input strings.
 
 | Version | URL | Notes |
 |---------|-----|-------|
-| **v1.1** (prep) | [GitHub Pages demo](https://jml6m.github.io/fas-js/demo/v1.1/) | Self-hosted in this repo (`demo/v1.1/`); uses current `fasJs` bundle |
+| **v1.1** (prep) | [GitHub Pages demo](https://jml6m.github.io/fas-js/v1.1/) | Self-hosted in this repo (`demo/v1.1/`); uses current `fasJs` bundle |
 | **v1** (legacy) | [ObservableHQ](https://observablehq.com/@jml6m/state-machine-simulator) | Original demo; kept for legacy reference |
 
 See [demo/README.md](demo/README.md) for local development and deployment details.

--- a/demo/README.md
+++ b/demo/README.md
@@ -7,7 +7,7 @@ This folder contains two versions of the finite state automaton simulator UI.
 | Path | Description | URL |
 |------|-------------|-----|
 | `v1/` | Legacy redirect page pointing to the original [ObservableHQ notebook](https://observablehq.com/@jml6m/state-machine-simulator) | Local file only |
-| `v1.1/` | Self-hosted, vanilla JS demo using the `fas-js` browser bundle | https://jml6m.github.io/fas-js/demo/v1.1/ |
+| `v1.1/` | Self-hosted, vanilla JS demo using the `fas-js` browser bundle | https://jml6m.github.io/fas-js/v1.1/ |
 
 ### v1 — Observable (legacy)
 
@@ -52,6 +52,9 @@ The workflow:
 
 1. Runs `npm ci && npm run build`
 2. Copies `lib/bundle.js` to `demo/v1.1/vendor/fas-js.bundle.js`
-3. Publishes the `demo/v1.1/` directory to GitHub Pages
+3. Publishes the `demo/` directory to GitHub Pages
 
-Public URL: **https://jml6m.github.io/fas-js/demo/v1.1/**
+Public URLs:
+
+- v1.1 demo: **https://jml6m.github.io/fas-js/v1.1/**
+- v1 legacy redirect: **https://jml6m.github.io/fas-js/v1/**

--- a/docs/v1.1-prep/PHASE3_READY.md
+++ b/docs/v1.1-prep/PHASE3_READY.md
@@ -8,7 +8,7 @@ Use this before starting the TypeScript + tsup modernization PR stack.
 - [x] Windows `npm test` fix (#220, nyc 17)
 - [x] API contract tests (#221)
 - [x] Audit docs: dependencies, dependabot, build spec, TS plan, test runner, coverage, security
-- [x] Demo v1.1 in-repo + GitHub Pages workflow (#223)
+- [x] Demo v1.1 in-repo + GitHub Pages workflow (#223) — https://jml6m.github.io/fas-js/v1.1/
 - [x] README + demo links (#224)
 - [x] Release runbook (#225)
 

--- a/docs/v1.1-prep/release-runbook.md
+++ b/docs/v1.1-prep/release-runbook.md
@@ -7,7 +7,7 @@ Closes [#225](https://github.com/jml6m/fas-js/issues/225).
 - [ ] All Phase 3 PRs merged to `main-v1-1-prep`
 - [ ] `npm test` passes at 100% coverage (or documented exceptions)
 - [ ] API contract tests pass
-- [ ] Demo deployed: https://jml6m.github.io/fas-js/demo/v1.1/
+- [ ] Demo deployed: https://jml6m.github.io/fas-js/v1.1/
 - [ ] README updated
 - [ ] Human reviews final PR
 


### PR DESCRIPTION
Fixes Pages deployment structure:

- Upload \demo/\ artifact so v1.1 is at /fas-js/v1.1/ (not site root)
- Correct public URLs in README and docs