### PR TITLE
feat(demo): copy-paste createFSA JSON + coverage policy alignment

### DIFF
--- a/.c8rc.json
+++ b/.c8rc.json
@@ -4,8 +4,8 @@
   "exclude": ["src/**/*.d.ts", "src/interfaces/**", "src/**/index.ts", "test/**"],
   "reporter": ["text-summary", "lcov"],
   "check-coverage": true,
-  "lines": 99,
-  "statements": 99,
-  "functions": 100,
-  "branches": 93
+  "lines": 90,
+  "statements": 90,
+  "functions": 90,
+  "branches": 90
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,7 @@ npm test            # build + mocha + c8 coverage
 
 - `lib/` is tracked as an empty directory via `lib/.gitkeep` (build output is gitignored).
 - TypeScript is checked via `npm run typecheck` and declaration emit during `npm run build`.
-- Coverage threshold on `main-v1-1-prep`: **99%** lines/statements (100% on Node 22), **100%** functions, **93%** branches (c8 in `npm test`). Interface-only and barrel `index.ts` files are excluded; minor cross-node V8 variance is expected on the CI matrix.
+- Coverage threshold on `main-v1-1-prep`: **90%** lines/statements/functions/branches (c8 in `npm test`). Tests target workflows and contracts, not line-hit goals. See `docs/v1.1-prep/coverage-policy.md`.
 
 ---
 

--- a/demo/README.md
+++ b/demo/README.md
@@ -22,8 +22,9 @@ The v1.1 demo is a static site with no npm build step of its own. It loads:
 
 Features:
 
-- Define a custom DFA or NFA (states, alphabet, transitions JSON, start, accepts)
-- Load built-in examples (DFA ending in `1`, NFA accepting `01` or `1`)
+- **Copy/paste editor** — one JSON object matching `createFSA` arguments (`states`, `alphabet`, `transitions`, `start`, `accepts`; optional `defaultInput`)
+- **Four presets** — 2 DFAs + 2 NFAs from the test suite / README
+- **Copy definition** button for scratchpad ↔ demo workflow
 - Build via `createFSA()` with validation feedback
 - Full simulation via `simulateFSA()`
 - Step-through mode via `stepOnceFSA()`

--- a/demo/v1.1/app.js
+++ b/demo/v1.1/app.js
@@ -17,6 +17,25 @@
       accepts: ["q2"],
       defaultInput: "101",
     },
+    dfaSameSymbolEnds: {
+      states: ["s", "q1", "q2", "r1", "r2"],
+      alphabet: "ab",
+      transitions: [
+        { from: "s", to: "q1", input: "a" },
+        { from: "s", to: "r1", input: "b" },
+        { from: "q1", to: "q1", input: "a" },
+        { from: "q1", to: "q2", input: "b" },
+        { from: "q2", to: "q1", input: "a" },
+        { from: "q2", to: "q2", input: "b" },
+        { from: "r1", to: "r2", input: "a" },
+        { from: "r1", to: "r1", input: "b" },
+        { from: "r2", to: "r2", input: "a" },
+        { from: "r2", to: "r1", input: "b" },
+      ],
+      start: "s",
+      accepts: ["q1", "r1"],
+      defaultInput: "bab",
+    },
     nfaAccepts01or1: {
       states: ["q1", "q2", "q3", "q4"],
       alphabet: "01",
@@ -31,15 +50,28 @@
       accepts: ["q3", "q4"],
       defaultInput: "01",
     },
+    nfaOneNearEnd: {
+      states: ["q1", "q2", "q3", "q4"],
+      alphabet: "01",
+      transitions: [
+        { from: "q1", to: "q1", input: "0" },
+        { from: "q1", to: "q1,q2", input: "1" },
+        { from: "q2", to: "q3", input: "0" },
+        { from: "q2", to: "q3", input: "1" },
+        { from: "q2", to: "q3", input: "" },
+        { from: "q3", to: "q4", input: "0" },
+        { from: "q3", to: "q4", input: "1" },
+      ],
+      start: "q1",
+      accepts: ["q4"],
+      defaultInput: "100",
+    },
   };
 
   const exampleSelectEl = document.getElementById("example-select");
-  const statesEl = document.getElementById("states-input");
-  const alphabetEl = document.getElementById("alphabet-input");
-  const startEl = document.getElementById("start-input");
-  const acceptsEl = document.getElementById("accepts-input");
-  const transitionsEl = document.getElementById("transitions-input");
+  const definitionEl = document.getElementById("fsa-definition");
   const buildBtn = document.getElementById("build-btn");
+  const copyBtn = document.getElementById("copy-btn");
   const buildStatusEl = document.getElementById("build-status");
 
   const inputEl = document.getElementById("input-string");
@@ -63,57 +95,67 @@
   let graphvizReady = false;
   let stepSession = null;
 
-  function splitList(value) {
-    return value
-      .split(/[,\s]+/)
-      .map(function (part) {
-        return part.trim();
-      })
-      .filter(Boolean);
+  function normalizeAccepts(accepts) {
+    if (typeof accepts === "string") {
+      return [accepts];
+    }
+    if (!Array.isArray(accepts)) {
+      throw new Error("accepts must be a string or string array.");
+    }
+    return accepts;
   }
 
-  function parseAlphabet(value) {
-    const trimmed = value.trim();
-    if (!trimmed) {
-      throw new Error("Alphabet cannot be empty.");
-    }
-    if (trimmed.includes(",")) {
-      return splitList(trimmed);
-    }
-    return trimmed.split("");
-  }
-
-  function readDefinitionFromForm() {
-    const states = splitList(statesEl.value);
-    if (!states.length) {
-      throw new Error("At least one state is required.");
-    }
-
-    const alphabet = parseAlphabet(alphabetEl.value);
-    const start = startEl.value.trim();
-    if (!start) {
-      throw new Error("Start state is required.");
-    }
-
-    const accepts = splitList(acceptsEl.value);
-    let transitions;
+  function parseDefinition(text) {
+    let raw;
     try {
-      transitions = JSON.parse(transitionsEl.value);
+      raw = JSON.parse(text);
     } catch (error) {
-      throw new Error("Transitions must be valid JSON.");
+      throw new Error("Definition must be valid JSON.");
     }
 
-    if (!Array.isArray(transitions) || !transitions.length) {
-      throw new Error("Transitions must be a non-empty JSON array.");
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+      throw new Error("Definition must be a JSON object.");
+    }
+
+    const required = ["states", "alphabet", "transitions", "start", "accepts"];
+    for (const key of required) {
+      if (raw[key] === undefined || raw[key] === null) {
+        throw new Error('Missing required field "' + key + '".');
+      }
+    }
+
+    if (!Array.isArray(raw.states) || !raw.states.length) {
+      throw new Error("states must be a non-empty array.");
+    }
+
+    if (
+      typeof raw.alphabet !== "string" &&
+      !(Array.isArray(raw.alphabet) && raw.alphabet.length)
+    ) {
+      throw new Error("alphabet must be a string or non-empty string array.");
+    }
+
+    if (!Array.isArray(raw.transitions) || !raw.transitions.length) {
+      throw new Error("transitions must be a non-empty array.");
+    }
+
+    if (typeof raw.start !== "string" || !raw.start) {
+      throw new Error("start must be a non-empty string.");
     }
 
     return {
-      states: states,
-      alphabet: alphabet,
-      transitions: transitions,
-      start: start,
-      accepts: accepts,
+      states: raw.states,
+      alphabet: raw.alphabet,
+      transitions: raw.transitions,
+      start: raw.start,
+      accepts: normalizeAccepts(raw.accepts),
+      defaultInput:
+        typeof raw.defaultInput === "string" ? raw.defaultInput : "",
     };
+  }
+
+  function formatDefinition(definition) {
+    return JSON.stringify(definition, null, 2);
   }
 
   function setBuildStatus(message, tone) {
@@ -138,14 +180,8 @@
       return;
     }
 
-    statesEl.value = example.states.join(",");
-    alphabetEl.value = Array.isArray(example.alphabet)
-      ? example.alphabet.join(",")
-      : example.alphabet;
-    startEl.value = example.start;
-    acceptsEl.value = example.accepts.join(",");
-    transitionsEl.value = JSON.stringify(example.transitions, null, 2);
-    inputEl.value = example.defaultInput;
+    definitionEl.value = formatDefinition(example);
+    inputEl.value = example.defaultInput || "";
   }
 
   function buildFSA() {
@@ -158,7 +194,7 @@
     }
 
     try {
-      const definition = readDefinitionFromForm();
+      const definition = parseDefinition(definitionEl.value);
       fsa = createFSA(
         definition.states,
         definition.alphabet,
@@ -168,9 +204,12 @@
       );
       fsaDef = definition;
       fsaTypeEl.textContent = fsa.getType();
+      if (definition.defaultInput) {
+        inputEl.value = definition.defaultInput;
+      }
       stepSession = createStepSession(readInput());
       setBuildStatus(
-        fsa.getType() + " built with " + definition.states.length + " states.",
+        fsa.getType() + " built — " + definition.states.length + " states.",
         "ok"
       );
       setResult("FSA ready. Enter an input string and press Simulate or Step.", "idle");
@@ -182,10 +221,25 @@
       fsaDef = null;
       fsaTypeEl.textContent = "—";
       setBuildStatus("Build failed: " + error.message, "error");
-      setResult("Fix the FSA definition and press Build FSA again.", "error");
+      setResult("Fix the JSON definition and press Build FSA again.", "error");
       graphEl.innerHTML =
         '<p class="graph-placeholder">Build an FSA to render its graph.</p>';
       return false;
+    }
+  }
+
+  async function copyDefinition() {
+    const text = definitionEl.value;
+    try {
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        await navigator.clipboard.writeText(text);
+      } else {
+        definitionEl.select();
+        document.execCommand("copy");
+      }
+      setBuildStatus("Definition copied to clipboard.", "ok");
+    } catch (error) {
+      setBuildStatus("Copy failed: " + error.message, "error");
     }
   }
 
@@ -414,6 +468,7 @@
     });
 
     buildBtn.addEventListener("click", buildFSA);
+    copyBtn.addEventListener("click", copyDefinition);
     simulateBtn.addEventListener("click", handleSimulate);
     resetBtn.addEventListener("click", handleReset);
     stepBtn.addEventListener("click", handleStep);

--- a/demo/v1.1/index.html
+++ b/demo/v1.1/index.html
@@ -17,9 +17,9 @@
           <p class="eyebrow">fas-js demo</p>
           <h1>Finite State Automaton Simulator</h1>
           <p class="subtitle">
-            Define a DFA or NFA, build it with <code>createFSA</code>, then run a
-            full simulation or step through an input string one symbol at a time.
-            The graph highlights the active state.
+            Paste a machine in <code>createFSA</code> format, build it, then
+            simulate or step through inputs. Copy definitions between this page
+            and your notes.
           </p>
         </div>
         <div class="header__meta">
@@ -36,91 +36,53 @@
 
       <main class="layout">
         <section class="panel editor-panel" aria-labelledby="editor-heading">
-          <h2 id="editor-heading">Define FSA</h2>
+          <h2 id="editor-heading">FSA definition</h2>
 
           <label class="field" for="example-select">
             <span class="field__label">Load example</span>
             <select id="example-select">
               <option value="dfaEndsIn1">DFA — strings ending in 1</option>
+              <option value="dfaSameSymbolEnds">
+                DFA — starts and ends with same symbol (a/b)
+              </option>
               <option value="nfaAccepts01or1">NFA — accepts 01 or 1</option>
+              <option value="nfaOneNearEnd">
+                NFA — 1 in 2nd or 3rd position from end
+              </option>
             </select>
           </label>
 
-          <label class="field" for="states-input">
-            <span class="field__label">States (Q)</span>
-            <input
-              id="states-input"
-              type="text"
-              value="q1,q2"
-              placeholder="q1,q2,q3"
-              autocomplete="off"
-              spellcheck="false"
-            />
-          </label>
-
-          <label class="field" for="alphabet-input">
-            <span class="field__label">Alphabet (Σ)</span>
-            <input
-              id="alphabet-input"
-              type="text"
-              value="01"
-              placeholder="01 or a,b"
-              autocomplete="off"
-              spellcheck="false"
-            />
-          </label>
-
-          <label class="field" for="start-input">
-            <span class="field__label">Start state (q0)</span>
-            <input
-              id="start-input"
-              type="text"
-              value="q1"
-              autocomplete="off"
-              spellcheck="false"
-            />
-          </label>
-
-          <label class="field" for="accepts-input">
-            <span class="field__label">Accept states (F)</span>
-            <input
-              id="accepts-input"
-              type="text"
-              value="q2"
-              placeholder="q2 or q1,q4"
-              autocomplete="off"
-              spellcheck="false"
-            />
-          </label>
-
-          <label class="field" for="transitions-input">
-            <span class="field__label">Transitions (δ) — JSON array</span>
+          <label class="field" for="fsa-definition">
+            <span class="field__label"
+              >Machine JSON (<code>createFSA</code> arguments)</span
+            >
             <textarea
-              id="transitions-input"
-              rows="8"
+              id="fsa-definition"
+              rows="18"
               spellcheck="false"
-            >[
-  { "from": "q1", "to": "q2", "input": "1" },
-  { "from": "q2", "to": "q1", "input": "0" },
-  { "from": "q2", "to": "q2", "input": "1" },
-  { "from": "q1", "to": "q1", "input": "0" }
-]</textarea>
+              aria-describedby="fsa-format-hint"
+            ></textarea>
           </label>
 
-          <p class="hint">
-            For NFAs use comma-separated destinations in <code>to</code> and
-            <code>""</code> for ε transitions. A complete DFA needs every
-            state × symbol pair.
+          <p id="fsa-format-hint" class="hint">
+            Object fields: <code>states</code>, <code>alphabet</code>,
+            <code>transitions</code>, <code>start</code>, <code>accepts</code>.
+            Optional <code>defaultInput</code> sets the simulation string.
+            NFAs: comma-separated <code>to</code> states;
+            <code>""</code> for ε.
           </p>
 
           <div class="button-row">
             <button id="build-btn" type="button" class="btn btn--primary">
               Build FSA
             </button>
+            <button id="copy-btn" type="button" class="btn btn--ghost">
+              Copy definition
+            </button>
           </div>
 
           <div id="build-status" class="build-status" role="status" aria-live="polite">
-            Press Build FSA to validate and load the machine.
+            Paste or load an example, then press Build FSA.
           </div>
         </section>
 
@@ -189,8 +151,7 @@
             <p class="graph-placeholder">Build an FSA to render its graph.</p>
           </div>
           <p class="footnote">
-            Graph rendered from <code>fsa.generateDigraph()</code> using D3,
-            d3-graphviz, and Graphviz WASM.
+            Graph from <code>fsa.generateDigraph()</code> (D3 + Graphviz WASM).
           </p>
         </section>
       </main>

--- a/docs/v1.1-prep/coverage-policy.md
+++ b/docs/v1.1-prep/coverage-policy.md
@@ -1,38 +1,34 @@
-# Coverage Policy — 100% with Documented Exceptions
+# Coverage Policy — Workflow-First (v1.1)
 
-Closes [#219](https://github.com/jml6m/fas-js/issues/219).
+Closes [#219](https://github.com/jml6m/fas-js/issues/219). Revised per maintainer direction in epic [#241](https://github.com/jml6m/fas-js/issues/241).
+
+## Philosophy
+
+Coverage is a **sanity check**, not the definition of done. Tests must prove **workflows and contracts** (API behavior, error codes, artifact fidelity, generated-machine equivalence). Do **not** add tests whose only purpose is to execute an uncovered line — especially legacy logging branches.
 
 ## Targets
 
-| Branch | Line coverage gate |
-|--------|-------------------|
-| `master` | 90% (current nyc config) |
-| `main-v1-1-prep` | **100%** after Phase 3 test-stack PR |
+| Branch | Gate (c8) |
+|--------|-----------|
+| `master` | 90% lines (legacy) |
+| `main-v1-1-prep` | **90%** lines, statements, functions, branches |
 
-## Current inventory (pre-Phase 3, nyc 17)
+Aspire toward higher coverage when it falls out naturally from meaningful tests. The floor is ~90%; there is no reward for 100% line hits without behavioral assertions.
 
-| Metric | Coverage |
-|--------|----------|
-| Lines | 99.69% (330/331) |
-| Statements | 99.74% (397/398) |
-| Branches | 98.38% (243/247) |
-| Functions | 100% (60/60) |
+## CI config
 
-**Gap:** 1 uncovered line + 4 uncovered branches in `src/`. Identify and cover during Phase 3, or document exception.
+See `.c8rc.json` — all four metrics at 90%. Interface-only files and barrel `index.ts` re-exports are excluded.
 
 ## Exception process
 
-1. Must be a genuinely complex edge case (e.g. unreachable defensive branch).
-2. Inline comment: `// coverage:ignore-next-line — reason, see #NNN`
-3. Linked GitHub issue explaining why 100% is impractical.
-4. Reviewer approval required.
+Only for genuinely unreachable defensive code:
 
-## Phase 3 config change
+1. Inline comment: `// coverage:ignore-next-line — reason, see #NNN`
+2. Linked GitHub issue
+3. Reviewer approval
 
-```json
-"c8": {
-  "check-coverage": true,
-  "lines": 100,
-  "include": ["src/**/*.ts"]
-}
-```
+## Related work
+
+- #238 — prune coverage-driven tests; align docs with enforced thresholds
+- #235 — validate `lib/` artifacts, not only `src/` via tsx
+- #240 — property-based / generated DFA checks


### PR DESCRIPTION
## Summary

- Demo: single **copy/paste JSON** editor in `createFSA` shape; **4 presets** (2 DFAs, 2 NFAs); copy button
- Policy: **90% coverage floor**, workflow-first philosophy (no line-hit chasing)

Closes #242. Part of epic #241.

## Demo format

\\\json
{
  \"states\": [\"q1\", \"q2\"],
  \"alphabet\": \"01\",
  \"transitions\": [{ \"from\": \"q1\", \"to\": \"q2\", \"input\": \"1\" }],
  \"start\": \"q1\",
  \"accepts\": [\"q2\"],
  \"defaultInput\": \"101\"
}
\\\

Paste from README / scratchpad → Build → simulate / step / graph.