### PR TITLE
feat: workflow tests, CLI digraph golden, demo UX hardening

### DIFF
--- a/demo/v1.1/app.js
+++ b/demo/v1.1/app.js
@@ -93,6 +93,9 @@
   let fsaDef = null;
   let graphviz = null;
   let graphvizReady = false;
+  let graphRenderGeneration = 0;
+  let graphRenderInFlight = null;
+  let resizeObserver = null;
   let stepSession = null;
 
   function normalizeAccepts(accepts) {
@@ -294,22 +297,105 @@
     return highlighted;
   }
 
+  function fitGraphToViewport() {
+    const svg = graphEl.querySelector("svg");
+    if (!svg) {
+      return;
+    }
+
+    const pad = 10;
+    let bbox;
+    try {
+      bbox = svg.getBBox();
+    } catch (error) {
+      return;
+    }
+
+    if (!bbox.width || !bbox.height) {
+      return;
+    }
+
+    const viewBox = [
+      bbox.x - pad,
+      bbox.y - pad,
+      bbox.width + pad * 2,
+      bbox.height + pad * 2,
+    ].join(" ");
+
+    svg.setAttribute("viewBox", viewBox);
+    svg.removeAttribute("width");
+    svg.removeAttribute("height");
+    svg.style.width = "100%";
+    svg.style.height = "100%";
+    svg.style.maxWidth = "100%";
+    svg.style.maxHeight = "100%";
+    svg.style.display = "block";
+    svg.setAttribute("preserveAspectRatio", "xMidYMid meet");
+  }
+
   async function renderGraph(highlightState) {
     if (!fsa) {
       return;
     }
 
-    try {
+    const generation = ++graphRenderGeneration;
+
+    if (graphRenderInFlight) {
+      try {
+        await graphRenderInFlight;
+      } catch (error) {
+        /* superseded render failed; continue */
+      }
+      if (generation !== graphRenderGeneration) {
+        return;
+      }
+    }
+
+    const renderTask = (async function () {
       await ensureGraphviz();
+      if (generation !== graphRenderGeneration) {
+        return;
+      }
+
       const dot = highlightStateInDot(fsa.generateDigraph(), highlightState);
-      graphEl.innerHTML = "";
       await graphviz.renderDot(dot);
+
+      if (generation !== graphRenderGeneration) {
+        return;
+      }
+
+      const placeholder = graphEl.querySelector(".graph-placeholder");
+      if (placeholder) {
+        placeholder.remove();
+      }
+
+      fitGraphToViewport();
+    })();
+
+    graphRenderInFlight = renderTask;
+
+    try {
+      await renderTask;
     } catch (error) {
+      if (generation !== graphRenderGeneration) {
+        return;
+      }
       graphvizReady = false;
       graphviz = null;
       graphEl.innerHTML =
         '<p class="graph-error">Graph render failed: ' + error.message + "</p>";
+    } finally {
+      if (graphRenderInFlight === renderTask) {
+        graphRenderInFlight = null;
+      }
     }
+  }
+
+  function scheduleGraphReflow() {
+    if (!fsa) {
+      return;
+    }
+    fitGraphToViewport();
   }
 
   function formatState(state) {
@@ -499,6 +585,16 @@
     bindEvents();
     loadExample(exampleSelectEl.value);
     buildFSA();
+
+    const viewport = document.getElementById("graph-viewport");
+    if (window.ResizeObserver && viewport) {
+      resizeObserver = new ResizeObserver(function () {
+        scheduleGraphReflow();
+      });
+      resizeObserver.observe(viewport);
+    }
+
+    window.addEventListener("resize", scheduleGraphReflow);
   }
 
   init();

--- a/demo/v1.1/index.html
+++ b/demo/v1.1/index.html
@@ -52,13 +52,12 @@
             </select>
           </label>
 
-          <label class="field" for="fsa-definition">
+          <label class="field field--grow" for="fsa-definition">
             <span class="field__label"
               >Machine JSON (<code>createFSA</code> arguments)</span
             >
             <textarea
               id="fsa-definition"
-              rows="18"
               spellcheck="false"
               aria-describedby="fsa-format-hint"
             ></textarea>
@@ -147,8 +146,10 @@
 
         <section class="panel graph-panel" aria-labelledby="graph-heading">
           <h2 id="graph-heading">State machine graph</h2>
-          <div id="graph" class="graph" aria-label="FSA graph visualization">
-            <p class="graph-placeholder">Build an FSA to render its graph.</p>
+          <div class="graph-viewport" id="graph-viewport">
+            <div id="graph" class="graph" aria-label="FSA graph visualization">
+              <p class="graph-placeholder">Build an FSA to render its graph.</p>
+            </div>
           </div>
           <p class="footnote">
             Graph from <code>fsa.generateDigraph()</code> (D3 + Graphviz WASM).

--- a/demo/v1.1/styles.css
+++ b/demo/v1.1/styles.css
@@ -1,20 +1,21 @@
 :root {
   color-scheme: light;
-  --bg: #f4f7fb;
+  --bg: #eef2f8;
   --surface: #ffffff;
   --text: #0f172a;
   --muted: #64748b;
-  --border: #dbe3ef;
-  --primary: #2563eb;
-  --primary-hover: #1d4ed8;
+  --border: #d6deea;
+  --primary: #1d4ed8;
+  --primary-hover: #1e40af;
+  --primary-soft: #dbeafe;
   --accept: #166534;
-  --accept-bg: #dcfce7;
+  --accept-bg: #ecfdf3;
   --reject: #b91c1c;
-  --reject-bg: #fee2e2;
+  --reject-bg: #fef2f2;
   --error: #9a3412;
-  --error-bg: #ffedd5;
-  --shadow: 0 18px 40px rgba(15, 23, 42, 0.08);
-  --radius: 18px;
+  --error-bg: #fff7ed;
+  --shadow: 0 10px 30px rgba(15, 23, 42, 0.06);
+  --radius: 16px;
   --font: "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
   --mono: "Cascadia Code", "SFMono-Regular", Consolas, monospace;
 }
@@ -25,41 +26,52 @@
   box-sizing: border-box;
 }
 
+html,
 body {
+  height: 100%;
   margin: 0;
-  min-height: 100vh;
+  overflow: hidden;
+}
+
+body {
   font-family: var(--font);
   color: var(--text);
   background:
-    radial-gradient(circle at top left, rgba(37, 99, 235, 0.12), transparent 28%),
-    linear-gradient(180deg, #eef4ff 0%, var(--bg) 45%, #f8fafc 100%);
+    radial-gradient(circle at 12% 8%, rgba(29, 78, 216, 0.1), transparent 32%),
+    linear-gradient(165deg, #f8fbff 0%, var(--bg) 55%, #f1f5f9 100%);
 }
 
 code {
   font-family: var(--mono);
-  font-size: 0.92em;
-  background: #eef2ff;
-  padding: 0.12rem 0.35rem;
+  font-size: 0.9em;
+  background: var(--primary-soft);
+  padding: 0.1rem 0.35rem;
   border-radius: 0.35rem;
 }
 
 .app {
-  width: min(1180px, calc(100% - 2rem));
+  height: 100dvh;
+  max-height: 100dvh;
+  width: min(1440px, 100%);
   margin: 0 auto;
-  padding: 2rem 0 3rem;
+  padding: 0.85rem 1rem 0.65rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  overflow: hidden;
 }
 
 .header {
   display: flex;
   justify-content: space-between;
-  gap: 1.5rem;
+  gap: 1rem;
   align-items: flex-start;
-  margin-bottom: 1.5rem;
+  flex: 0 0 auto;
 }
 
 .eyebrow {
-  margin: 0 0 0.35rem;
-  font-size: 0.82rem;
+  margin: 0 0 0.2rem;
+  font-size: 0.75rem;
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -67,33 +79,35 @@ code {
 }
 
 .header h1 {
-  margin: 0 0 0.75rem;
-  font-size: clamp(1.9rem, 4vw, 2.6rem);
-  line-height: 1.1;
+  margin: 0 0 0.35rem;
+  font-size: clamp(1.35rem, 2.2vw, 2rem);
+  line-height: 1.15;
 }
 
 .subtitle {
   margin: 0;
-  max-width: 52rem;
+  max-width: 48rem;
   color: var(--muted);
-  line-height: 1.6;
+  line-height: 1.45;
+  font-size: 0.92rem;
 }
 
 .header__meta {
   display: flex;
   flex-direction: column;
   align-items: flex-end;
-  gap: 0.75rem;
+  gap: 0.5rem;
+  flex-shrink: 0;
 }
 
 .badge {
   display: inline-flex;
   align-items: center;
-  padding: 0.35rem 0.7rem;
+  padding: 0.3rem 0.65rem;
   border-radius: 999px;
-  background: #dbeafe;
+  background: var(--primary-soft);
   color: #1e3a8a;
-  font-size: 0.82rem;
+  font-size: 0.78rem;
   font-weight: 700;
 }
 
@@ -101,6 +115,7 @@ code {
   color: var(--primary);
   text-decoration: none;
   font-weight: 600;
+  font-size: 0.88rem;
 }
 
 .link:hover {
@@ -108,9 +123,12 @@ code {
 }
 
 .layout {
+  flex: 1 1 auto;
+  min-height: 0;
   display: grid;
-  grid-template-columns: minmax(260px, 1fr) minmax(280px, 360px) minmax(0, 1.35fr);
-  gap: 1.25rem;
+  grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.9fr) minmax(0, 1.15fr);
+  gap: 0.85rem;
+  overflow: hidden;
 }
 
 .panel {
@@ -118,27 +136,41 @@ code {
   border: 1px solid var(--border);
   border-radius: var(--radius);
   box-shadow: var(--shadow);
-  padding: 1.35rem;
+  padding: 0.95rem 1rem;
+  min-height: 0;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
 }
 
 .panel h2,
 .section-title {
-  margin: 0 0 1rem;
-  font-size: 1.1rem;
+  margin: 0 0 0.65rem;
+  font-size: 1rem;
+  flex: 0 0 auto;
 }
 
 .section-title {
   margin-top: 0;
 }
 
+.editor-panel .field--grow {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 0.65rem;
+}
+
 .field {
   display: grid;
-  gap: 0.45rem;
-  margin-bottom: 1rem;
+  gap: 0.35rem;
+  margin-bottom: 0.65rem;
+  flex: 0 0 auto;
 }
 
 .field__label {
-  font-size: 0.92rem;
+  font-size: 0.84rem;
   font-weight: 600;
 }
 
@@ -146,25 +178,27 @@ code {
 .field select,
 .field textarea {
   width: 100%;
-  padding: 0.8rem 0.95rem;
+  padding: 0.62rem 0.75rem;
   border: 1px solid var(--border);
-  border-radius: 12px;
+  border-radius: 10px;
   font: inherit;
   background: #f8fafc;
 }
 
 .field textarea {
-  resize: vertical;
-  min-height: 10rem;
+  flex: 1 1 auto;
+  min-height: 0;
+  resize: none;
+  overflow: hidden;
   font-family: var(--mono);
-  font-size: 0.86rem;
-  line-height: 1.45;
+  font-size: 0.8rem;
+  line-height: 1.4;
 }
 
 .field input:focus,
 .field select:focus,
 .field textarea:focus {
-  outline: 2px solid rgba(37, 99, 235, 0.25);
+  outline: 2px solid rgba(29, 78, 216, 0.2);
   border-color: var(--primary);
   background: #fff;
 }
@@ -172,17 +206,19 @@ code {
 .button-row {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.65rem;
+  gap: 0.5rem;
+  flex: 0 0 auto;
 }
 
 .btn {
   appearance: none;
   border: 1px solid var(--border);
-  border-radius: 12px;
+  border-radius: 10px;
   background: #fff;
   color: var(--text);
-  padding: 0.72rem 1rem;
+  padding: 0.58rem 0.85rem;
   font: inherit;
+  font-size: 0.88rem;
   font-weight: 600;
   cursor: pointer;
   transition: background 0.15s ease, border-color 0.15s ease, transform 0.15s ease;
@@ -215,26 +251,42 @@ code {
 .mode-divider {
   height: 1px;
   background: var(--border);
-  margin: 1.25rem 0;
+  margin: 0.75rem 0;
+  flex: 0 0 auto;
 }
 
 .hint {
-  margin: 0 0 1rem;
+  margin: 0 0 0.65rem;
   color: var(--muted);
-  font-size: 0.92rem;
-  line-height: 1.5;
+  font-size: 0.8rem;
+  line-height: 1.4;
+  flex: 0 0 auto;
+}
+
+.controls .hint,
+.controls .button-row,
+.controls .field,
+.controls .mode-divider,
+.controls .status-grid {
+  flex: 0 0 auto;
+}
+
+.controls .result {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: hidden;
 }
 
 .status-grid {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 0.75rem;
-  margin: 1.1rem 0;
+  gap: 0.5rem;
+  margin: 0.65rem 0;
 }
 
 .status-grid dt {
-  margin: 0 0 0.2rem;
-  font-size: 0.78rem;
+  margin: 0 0 0.15rem;
+  font-size: 0.72rem;
   text-transform: uppercase;
   letter-spacing: 0.05em;
   color: var(--muted);
@@ -243,21 +295,29 @@ code {
 .status-grid dd {
   margin: 0;
   font-family: var(--mono);
-  font-size: 0.95rem;
+  font-size: 0.86rem;
   font-weight: 700;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.result,
+.build-status {
+  padding: 0.7rem 0.8rem;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: #f8fafc;
+  line-height: 1.4;
+  font-size: 0.86rem;
 }
 
 .result {
-  margin-top: 1rem;
-  padding: 0.9rem 1rem;
-  border-radius: 12px;
-  border: 1px solid var(--border);
-  background: #f8fafc;
-  line-height: 1.5;
-  min-height: 3.25rem;
+  margin-top: 0.65rem;
 }
 
-.result--accept {
+.result--accept,
+.build-status--ok {
   color: var(--accept);
   background: var(--accept-bg);
   border-color: #86efac;
@@ -269,82 +329,72 @@ code {
   border-color: #fca5a5;
 }
 
-.result--error {
-  color: var(--error);
-  background: var(--error-bg);
-  border-color: #fdba74;
-}
-
-.result--idle {
-  color: var(--muted);
-}
-
-.build-status {
-  margin-top: 1rem;
-  padding: 0.85rem 1rem;
-  border-radius: 12px;
-  border: 1px solid var(--border);
-  background: #f8fafc;
-  color: var(--muted);
-  line-height: 1.5;
-}
-
-.build-status--ok {
-  color: var(--accept);
-  background: var(--accept-bg);
-  border-color: #86efac;
-}
-
+.result--error,
 .build-status--error {
   color: var(--error);
   background: var(--error-bg);
   border-color: #fdba74;
 }
 
+.result--idle,
+.build-status {
+  color: var(--muted);
+}
+
+.graph-panel {
+  min-height: 0;
+}
+
+.graph-viewport {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: linear-gradient(180deg, #fbfdff 0%, #f8fafc 100%);
+  padding: 0.35rem;
+}
+
+.graph {
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.graph svg {
+  display: block;
+}
+
 .graph-placeholder,
 .graph-error {
   margin: 0;
-  padding: 1.25rem;
+  padding: 1rem;
   color: var(--muted);
   text-align: center;
+  font-size: 0.86rem;
 }
 
 .graph-error {
   color: var(--error);
 }
 
-.graph-panel {
-  min-height: 520px;
-  display: flex;
-  flex-direction: column;
-}
-
-.graph {
-  flex: 1;
-  min-height: 420px;
-  overflow: auto;
-  border: 1px dashed var(--border);
-  border-radius: 14px;
-  background: linear-gradient(180deg, #fbfdff 0%, #f8fafc 100%);
-  padding: 0.5rem;
-}
-
-.graph svg {
-  width: 100%;
-  height: auto;
-  display: block;
-}
-
 .footnote {
-  margin: 0.85rem 0 0;
+  margin: 0.5rem 0 0;
   color: var(--muted);
-  font-size: 0.86rem;
+  font-size: 0.78rem;
+  flex: 0 0 auto;
 }
 
 .footer {
-  margin-top: 1.5rem;
+  flex: 0 0 auto;
   color: var(--muted);
-  font-size: 0.92rem;
+  font-size: 0.78rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .footer a {
@@ -352,14 +402,28 @@ code {
 }
 
 @media (max-width: 1100px) {
-  .header,
+  .layout {
+    grid-template-columns: 1fr 1fr;
+    grid-template-rows: minmax(0, 1fr) minmax(0, 1fr);
+  }
+
+  .editor-panel {
+    grid-column: 1 / -1;
+  }
+
+  .graph-panel {
+    grid-column: 1 / -1;
+  }
+}
+
+@media (max-width: 760px) {
   .layout {
     grid-template-columns: 1fr;
-    display: grid;
+    grid-template-rows: repeat(3, minmax(0, 1fr));
   }
 
   .header {
-    gap: 1rem;
+    flex-direction: column;
   }
 
   .header__meta {

--- a/test/digraph-cli.spec.js
+++ b/test/digraph-cli.spec.js
@@ -1,0 +1,63 @@
+/**
+ * CLI golden test: large digraph DOT output (no visualization).
+ * Verifies exact generateDigraph() bytes for a high state-count machine.
+ */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { createFSA } from "../src/modules";
+
+import { assert } from "chai";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FIXTURE = join(__dirname, "fixtures", "digraph-large-ring.expected.dot");
+
+function buildLargeRingDfa(stateCount) {
+  const states = Array.from({ length: stateCount }, (_, i) => "q" + i);
+  const transitions = [];
+
+  for (let i = 0; i < stateCount; i++) {
+    transitions.push({
+      from: "q" + i,
+      to: "q" + ((i + 1) % stateCount),
+      input: "0",
+    });
+    transitions.push({
+      from: "q" + i,
+      to: "q" + ((i + stateCount - 1) % stateCount),
+      input: "1",
+    });
+  }
+
+  return createFSA(states, "01", transitions, "q0", ["q8", "q16", "q24"]);
+}
+
+describe("CLI digraph golden output", function () {
+  it("matches exact DOT for 32-state ring DFA with multiple accept states", function () {
+    const fsa = buildLargeRingDfa(32);
+    const dot = fsa.generateDigraph();
+    const expected = readFileSync(FIXTURE, "utf8");
+
+    assert.equal(dot, expected);
+    assert.isAbove(dot.length, 2000);
+    assert.include(dot, "q16 [shape = doublecircle]");
+    assert.include(dot, "q31 -> q0 [ label = \"0\" ]");
+  });
+
+  it("merges duplicate edge labels in DOT for multi-input transitions", function () {
+    const fsa = createFSA(
+      ["a", "b"],
+      "01",
+      [
+        { from: "a", to: "b", input: "0" },
+        { from: "a", to: "b", input: "1" },
+        { from: "b", to: "a", input: "0" },
+        { from: "b", to: "b", input: "1" },
+      ],
+      "a",
+      ["b"]
+    );
+    const dot = fsa.generateDigraph();
+    assert.include(dot, 'a -> b [ label = "0,1" ]');
+  });
+});

--- a/test/fixtures/digraph-large-ring.expected.dot
+++ b/test/fixtures/digraph-large-ring.expected.dot
@@ -1,0 +1,103 @@
+digraph fsa {
+          q0
+	q1
+	q2
+	q3
+	q4
+	q5
+	q6
+	q7
+	q8 [shape = doublecircle];
+	q9
+	q10
+	q11
+	q12
+	q13
+	q14
+	q15
+	q16 [shape = doublecircle];
+	q17
+	q18
+	q19
+	q20
+	q21
+	q22
+	q23
+	q24 [shape = doublecircle];
+	q25
+	q26
+	q27
+	q28
+	q29
+	q30
+	q31
+          rankdir=LR;
+          node [shape = point ]; qi;
+          node [shape = circle];
+          qi -> q0;
+          q0 -> q1 [ label = "0" ];
+	q0 -> q31 [ label = "1" ];
+	q1 -> q2 [ label = "0" ];
+	q1 -> q0 [ label = "1" ];
+	q2 -> q3 [ label = "0" ];
+	q2 -> q1 [ label = "1" ];
+	q3 -> q4 [ label = "0" ];
+	q3 -> q2 [ label = "1" ];
+	q4 -> q5 [ label = "0" ];
+	q4 -> q3 [ label = "1" ];
+	q5 -> q6 [ label = "0" ];
+	q5 -> q4 [ label = "1" ];
+	q6 -> q7 [ label = "0" ];
+	q6 -> q5 [ label = "1" ];
+	q7 -> q8 [ label = "0" ];
+	q7 -> q6 [ label = "1" ];
+	q8 -> q9 [ label = "0" ];
+	q8 -> q7 [ label = "1" ];
+	q9 -> q10 [ label = "0" ];
+	q9 -> q8 [ label = "1" ];
+	q10 -> q11 [ label = "0" ];
+	q10 -> q9 [ label = "1" ];
+	q11 -> q12 [ label = "0" ];
+	q11 -> q10 [ label = "1" ];
+	q12 -> q13 [ label = "0" ];
+	q12 -> q11 [ label = "1" ];
+	q13 -> q14 [ label = "0" ];
+	q13 -> q12 [ label = "1" ];
+	q14 -> q15 [ label = "0" ];
+	q14 -> q13 [ label = "1" ];
+	q15 -> q16 [ label = "0" ];
+	q15 -> q14 [ label = "1" ];
+	q16 -> q17 [ label = "0" ];
+	q16 -> q15 [ label = "1" ];
+	q17 -> q18 [ label = "0" ];
+	q17 -> q16 [ label = "1" ];
+	q18 -> q19 [ label = "0" ];
+	q18 -> q17 [ label = "1" ];
+	q19 -> q20 [ label = "0" ];
+	q19 -> q18 [ label = "1" ];
+	q20 -> q21 [ label = "0" ];
+	q20 -> q19 [ label = "1" ];
+	q21 -> q22 [ label = "0" ];
+	q21 -> q20 [ label = "1" ];
+	q22 -> q23 [ label = "0" ];
+	q22 -> q21 [ label = "1" ];
+	q23 -> q24 [ label = "0" ];
+	q23 -> q22 [ label = "1" ];
+	q24 -> q25 [ label = "0" ];
+	q24 -> q23 [ label = "1" ];
+	q25 -> q26 [ label = "0" ];
+	q25 -> q24 [ label = "1" ];
+	q26 -> q27 [ label = "0" ];
+	q26 -> q25 [ label = "1" ];
+	q27 -> q28 [ label = "0" ];
+	q27 -> q26 [ label = "1" ];
+	q28 -> q29 [ label = "0" ];
+	q28 -> q27 [ label = "1" ];
+	q29 -> q30 [ label = "0" ];
+	q29 -> q28 [ label = "1" ];
+	q30 -> q31 [ label = "0" ];
+	q30 -> q29 [ label = "1" ];
+	q31 -> q0 [ label = "0" ];
+	q31 -> q30 [ label = "1" ];
+      }
+      

--- a/test/workflows.spec.js
+++ b/test/workflows.spec.js
@@ -1,0 +1,211 @@
+/**
+ * Workflow tests: generated FSAs and step/simulate equivalence.
+ */
+import { createFSA, simulateFSA, stepOnceFSA } from "../src/modules";
+
+import { assert } from "chai";
+
+function mulberry32(seed) {
+  return function () {
+    let t = (seed += 0x6d2b79f5);
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function randomString(rng, alphabet, maxLen) {
+  const len = Math.floor(rng() * (maxLen + 1));
+  let s = "";
+  for (let i = 0; i < len; i++) {
+    s += alphabet[Math.floor(rng() * alphabet.length)];
+  }
+  return s;
+}
+
+function buildRandomCompleteDfa(rng, stateCount, alphabet) {
+  const states = Array.from({ length: stateCount }, (_, i) => "s" + i);
+  const transitions = [];
+
+  for (const from of states) {
+    for (const input of alphabet) {
+      const to = states[Math.floor(rng() * stateCount)];
+      transitions.push({ from, to, input });
+    }
+  }
+
+  const acceptCount = 1 + Math.floor(rng() * stateCount);
+  const accepts = states.slice(0, acceptCount);
+
+  return createFSA(states, alphabet, transitions, states[0], accepts);
+}
+
+function referenceSimulateDfa(fsa, w) {
+  let state = fsa.getStartState();
+  const chars = w === "" ? [] : [...w];
+
+  for (const sym of chars) {
+    let dest = null;
+    for (const tr of fsa.getTFunc()) {
+      if (tr.origin === state && tr.input === sym) {
+        dest = tr.dest;
+        break;
+      }
+    }
+    if (!dest) {
+      return false;
+    }
+    state = dest;
+  }
+
+  return fsa.getAcceptStates().has(state);
+}
+
+function epsilonClosure(nfa, stateNames) {
+  let states = stateNames.map(name => {
+    for (const s of nfa.getStates()) {
+      if (s.name === name) return s;
+    }
+    throw new Error("state not found: " + name);
+  });
+
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const tr of nfa.getTFunc()) {
+      if (tr.input === "" && states.includes(tr.origin) && !states.includes(tr.dest)) {
+        states.push(tr.dest);
+        changed = true;
+      }
+    }
+  }
+
+  return states;
+}
+
+function referenceSimulateNfa(nfa, w) {
+  let states = epsilonClosure(nfa, [nfa.getStartState().name]);
+  const chars = w === "" ? [] : [...w];
+
+  for (const sym of chars) {
+    const next = [];
+    for (const state of states) {
+      for (const tr of nfa.getTFunc()) {
+        if (tr.origin === state && tr.input === sym) {
+          next.push(tr.dest);
+        }
+      }
+    }
+    states = epsilonClosure(
+      nfa,
+      next.map(s => s.name)
+    );
+    if (!states.length) {
+      return false;
+    }
+  }
+
+  for (const state of states) {
+    if (nfa.getAcceptStates().has(state)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function buildRandomNfa(rng) {
+  const states = ["n0", "n1", "n2", "n3"];
+  const transitions = [
+    { from: "n0", to: "n0", input: "0" },
+    { from: "n0", to: "n1", input: "1" },
+    { from: "n1", to: "n2", input: "0" },
+    { from: "n1", to: "n1,n2", input: "1" },
+    { from: "n2", to: "n3", input: "0" },
+    { from: "n2", to: "n2", input: "1" },
+    { from: "n3", to: "n3", input: "0" },
+    { from: "n3", to: "n3", input: "1" },
+  ];
+
+  if (rng() > 0.5) {
+    transitions.push({ from: "n1", to: "n3", input: "" });
+  }
+
+  const accepts = rng() > 0.5 ? ["n3"] : ["n2", "n3"];
+  return createFSA(states, "01", transitions, "n0", accepts);
+}
+
+describe("Generated FSA workflows", function () {
+  it("simulateFSA matches reference walk on seeded random complete DFAs", function () {
+    const rng = mulberry32(0xfa5a);
+    const alphabet = ["0", "1"];
+
+    for (let i = 0; i < 24; i++) {
+      const stateCount = 2 + Math.floor(rng() * 4);
+      const fsa = buildRandomCompleteDfa(rng, stateCount, alphabet);
+      assert.equal(fsa.getType(), "DFA");
+
+      for (let j = 0; j < 12; j++) {
+        const w = randomString(rng, alphabet, 6);
+        assert.equal(
+          simulateFSA(w, fsa),
+          referenceSimulateDfa(fsa, w),
+          `DFA ${i} input "${w}"`
+        );
+      }
+    }
+  });
+
+  it("simulateFSA matches reference NFA walk on seeded variants", function () {
+    const rng = mulberry32(0xfa5b);
+
+    for (let i = 0; i < 16; i++) {
+      const nfa = buildRandomNfa(rng);
+      assert.equal(nfa.getType(), "NFA");
+
+      for (let j = 0; j < 10; j++) {
+        const w = randomString(rng, ["0", "1"], 5);
+        assert.equal(
+          simulateFSA(w, nfa),
+          referenceSimulateNfa(nfa, w),
+          `NFA ${i} input "${w}"`
+        );
+      }
+    }
+  });
+});
+
+describe("Step vs simulate equivalence", function () {
+  const endsInOne = createFSA(
+    ["q1", "q2"],
+    "01",
+    [
+      { from: "q1", to: "q2", input: "1" },
+      { from: "q2", to: "q1", input: "0" },
+      { from: "q2", to: "q2", input: "1" },
+      { from: "q1", to: "q1", input: "0" },
+    ],
+    "q1",
+    ["q2"]
+  );
+
+  it("iterating stepOnceFSA agrees with simulateFSA for a DFA", function () {
+    const inputs = ["", "0", "1", "101", "10101", "0110"];
+
+    for (const w of inputs) {
+      let state = endsInOne.getStartState().name;
+
+      for (const sym of w) {
+        state = stepOnceFSA(sym, state, endsInOne);
+      }
+
+      const steppedAccepted = endsInOne.getAcceptStates().has(
+        [...endsInOne.getStates()].find(s => s.name === state)
+      );
+      const simulatedAccepted = simulateFSA(w, endsInOne);
+      const simulatedEnd = simulateFSA(w, endsInOne, false, true);
+
+      assert.equal(simulatedAccepted, steppedAccepted, `acceptance for "${w}"`);
+      assert.equal(simulatedEnd, state, `end state for "${w}"`);
+    }
+  });
+});


### PR DESCRIPTION
## Tests
- **Generated workflows** (`test/workflows.spec.js`): 24 seeded complete DFAs + 16 NFA variants vs independent reference simulator
- **Step/simulate equivalence**: `stepOnceFSA` iterated matches `simulateFSA` on README DFA
- **CLI digraph golden** (`test/digraph-cli.spec.js`): exact DOT for 32-state ring vs `test/fixtures/digraph-large-ring.expected.dot` — no image/visual testing

## Demo UX
- **No page scrollbars** — `100dvh` flex layout, panels clip internally
- **Stable graph** on Simulate / Step / Restart — render generation queue, no `innerHTML` clear before paint
- **Viewport cap** — SVG `viewBox` + `preserveAspectRatio: meet` sized to graph panel; `ResizeObserver` reflow

Part of epic #241. Progress on #240, #236, demo feedback.