### PR TITLE
Add helper scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
     "clean": "node scripts/prebuild.mjs",
     "prepublishOnly": "npm run build && npm test",
     "typecheck": "tsc --noEmit",
-    "test": "npm run build && cross-env NODE_OPTIONS=--import=tsx c8 mocha \"test/**/*.spec.js\""
+    "test": "npm run build && cross-env NODE_OPTIONS=--import=tsx c8 mocha \"test/**/*.spec.js\"",
+    "git:reset": "git reset --hard HEAD && git clean -fd",
+    "npm:reinstall": "node scripts/reinstall.js"
   },
   "author": "Joseph Lewkovich",
   "license": "GPL-3.0-or-later",

--- a/scripts/reinstall.js
+++ b/scripts/reinstall.js
@@ -23,6 +23,7 @@ console.log("✨ Clean complete. Installing fresh dependencies...");
 
 try {
   execSync("npm install", { stdio: "inherit", cwd: rootDir });
-} catch {
+} catch (error) {
+  console.error("❌ Install failed:", error.message);
   process.exit(1);
 }

--- a/scripts/reinstall.js
+++ b/scripts/reinstall.js
@@ -1,0 +1,28 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { execSync } from "node:child_process";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+console.log("🗑️  Cleaning dependencies...");
+
+const rootDir = path.resolve(__dirname, "..");
+const nodeModules = path.join(rootDir, "node_modules");
+const lockFile = path.join(rootDir, "package-lock.json");
+
+if (fs.existsSync(nodeModules)) {
+  fs.rmSync(nodeModules, { recursive: true, force: true });
+}
+
+if (fs.existsSync(lockFile)) {
+  fs.rmSync(lockFile, { force: true });
+}
+
+console.log("✨ Clean complete. Installing fresh dependencies...");
+
+try {
+  execSync("npm install", { stdio: "inherit", cwd: rootDir });
+} catch {
+  process.exit(1);
+}


### PR DESCRIPTION
## What

Adds developer convenience scripts to streamline common local workflows on the prep branch.

- `git:reset` — hard-resets the working tree and removes untracked files (`git reset --hard HEAD && git clean -fd`).
- `npm:reinstall` — removes `node_modules` and `package-lock.json`, then runs a fresh `npm install` via `scripts/reinstall.js`.

## Related issues

## Why

Provides quick, standardized shortcuts for common cleanup and dependency reset tasks during local development on `main-v1-1-prep`.

## How

- Added `git:reset` and `npm:reinstall` entries to the `scripts` section of `package.json`.
- Created `scripts/reinstall.js` using ESM syntax (`import`/`import.meta.url`) to match the project's `"type": "module"` setting and the style of the existing `scripts/prebuild.mjs` and `scripts/postbuild.mjs`. The script deletes `node_modules` and `package-lock.json`, then runs `npm install`, logging an error message if the install fails.

## How tested

- [ ] `npm ci`
- [ ] `npm test`
- [ ] `npm run flow check` (if Flow sources changed)
- [ ] Manual smoke test (if user-facing)

## Checklist

- [ ] PR targets `main-v1-1-prep` (not `master`, unless an approved stable hotfix)
- [ ] Changes are focused and minimal
- [ ] Tests added or updated for new/changed behavior
- [ ] Coverage maintained (100% on `main-v1-1-prep`; documented exceptions only)
- [ ] No version bump in `package.json`
- [ ] `AGENTS.md` / `README.md` updated if workflow or public API changed