### PR TITLE
docs: track releases via milestones, not labels (v1.1-prep retired)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,6 +58,10 @@ Use the GitHub issue templates — blank issues are disabled.
 2. Create the parent epic and paste those numbers into the task list.
 3. Use relationship keywords: `Blocked by #123`, `Depends on #123`, `Relates to #123`.
 
+### Release tracking — use Milestones, not labels
+
+Track which release an issue is scoped for with a GitHub **Milestone** (e.g. `v1.1`), never a label. Do **not** create or apply release-scoping labels such as `v1.1-prep`, `*-prep`, or `*-required` — that label was retired and its issues moved onto the `v1.1` milestone. Milestones intentionally carry **no due date** right now; they exist only to group the work that belongs to a release. Nothing in CI blocks a release-scoping label (enforcing that would mean brittle label-name regex), so this is a convention everyone follows: assign the milestone, don't invent a label.
+
 ---
 
 ## Versioning and releases


### PR DESCRIPTION
## What

Documents the team convention to **track releases with GitHub Milestones, not labels**, and records that the `v1.1-prep` label was retired.

## Why

Release-scoping labels (`v1.1-prep`, `*-prep`, etc.) duplicate what milestones already do and can't be reliably blocked in CI without brittle label-name regex. Milestones are the right primitive: group issues by target release, no due date for now.

## What changed in GitHub (already applied, outside this PR)

- A new **`v1.1`** milestone was created (no due date).
- All 21 issues that carried `v1.1-prep` (open + closed) were assigned to the `v1.1` milestone.
- The **`v1.1-prep`** label was deleted (auto-removing it from all issues).

## This PR

- `CONTRIBUTING.md`: adds a "Release tracking — use Milestones, not labels" subsection under Issues.

> Targeting `main-v2-workspace` per the documented default PR target in CONTRIBUTING.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
