### PR TITLE
Add protected-file lockdown CI gate

### DIFF
--- a/.github/PROTECTED_FILES.json
+++ b/.github/PROTECTED_FILES.json
@@ -1,0 +1,10 @@
+{
+  "patterns": [
+    "test/helpers/**",
+    "src/modules.ts",
+    "scripts/check-public-api.mjs",
+    "scripts/check-theorem-annotations.mjs",
+    "docs/function-annotation-protocol.md",
+    "package.json"
+  ]
+}

--- a/.github/PROTECTED_FILES.json
+++ b/.github/PROTECTED_FILES.json
@@ -3,8 +3,8 @@
     "test/helpers/**",
     "src/modules.ts",
     "scripts/check-public-api.mjs",
-    "scripts/check-theorem-annotations.mjs",
-    "docs/function-annotation-protocol.md",
+    "scripts/check-protected-files.mjs",
+    ".github/PROTECTED_FILES.json",
     "package.json"
   ]
 }

--- a/.github/workflows/lock-files.yml
+++ b/.github/workflows/lock-files.yml
@@ -16,12 +16,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          fetch-depth: 0
+      - name: Fetch base commit
+        run: git fetch --depth=1 origin ${{ github.event.pull_request.base.sha }}
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20
       - name: Check protected files
         env:
-          GITHUB_BASE_REF: ${{ github.base_ref }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: node scripts/check-protected-files.mjs

--- a/.github/workflows/lock-files.yml
+++ b/.github/workflows/lock-files.yml
@@ -1,0 +1,27 @@
+name: Lock Files
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: lock-files-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lock-files:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 20
+      - name: Check protected files
+        env:
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+        run: node scripts/check-protected-files.mjs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,16 +50,16 @@ Certain paths are locked by the `lock-files` CI check (see [`.github/PROTECTED_F
 | `test/helpers/**` | Contract test functions — changes break foundational test fidelity |
 | `src/modules.ts` | Public API entry point — signature changes require major version bump |
 | `scripts/check-public-api.mjs` | Enforces public API contract |
-| `scripts/check-theorem-annotations.mjs` | Enforces correctness labeling protocol |
-| `docs/function-annotation-protocol.md` | Defines theorem vs. spot-check distinctions |
+| `scripts/check-protected-files.mjs` | The CI gate itself — must not be bypassed without owner review |
+| `.github/PROTECTED_FILES.json` | Defines the protected-path list — changes alter what is locked |
 | `package.json` | Version, public exports, build config |
 
 **Override process** (when a protected change is intentional):
 
 1. Open a PR with a clear explanation of why the protected file must change.
 2. Wait for the `lock-files` check to fail — that failure is expected.
-3. Request maintainer review and tag `@jml6m`.
-4. The maintainer decides whether to merge as-is or request refinements.
+3. Request review and tag `@jml6m`.
+4. Only `@jml6m` (project owner) can merge changes that touch protected files.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,26 @@ New **public API** features are scheduled for **v2**; release branches ship demo
 
 - **Coverage floor**: **90%** on lines, statements, functions, and branches (c8). Tests target workflows and contracts, not line-hit goals. See [`docs/v1.1-prep/coverage-policy.md`](docs/v1.1-prep/coverage-policy.md) and [`docs/v1.1-prep/test-architecture.md`](docs/v1.1-prep/test-architecture.md).
 
+### Protected Files
+
+Certain paths are locked by the `lock-files` CI check (see [`.github/PROTECTED_FILES.json`](.github/PROTECTED_FILES.json)). Changes to these files require explicit maintainer approval.
+
+| Path | Why protected |
+|------|---------------|
+| `test/helpers/**` | Contract test functions — changes break foundational test fidelity |
+| `src/modules.ts` | Public API entry point — signature changes require major version bump |
+| `scripts/check-public-api.mjs` | Enforces public API contract |
+| `scripts/check-theorem-annotations.mjs` | Enforces correctness labeling protocol |
+| `docs/function-annotation-protocol.md` | Defines theorem vs. spot-check distinctions |
+| `package.json` | Version, public exports, build config |
+
+**Override process** (when a protected change is intentional):
+
+1. Open a PR with a clear explanation of why the protected file must change.
+2. Wait for the `lock-files` check to fail — that failure is expected.
+3. Request maintainer review and tag `@jml6m`.
+4. The maintainer decides whether to merge as-is or request refinements.
+
 ---
 
 ## Issues

--- a/scripts/check-protected-files.mjs
+++ b/scripts/check-protected-files.mjs
@@ -1,0 +1,98 @@
+/**
+ * CI gate: fail when a PR touches paths listed in .github/PROTECTED_FILES.json.
+ */
+import { execSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dir = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dir, "..");
+
+const GREEN = "\x1b[32m";
+const RED = "\x1b[31m";
+const RESET = "\x1b[0m";
+
+function globToRegExp(pattern) {
+  const normalized = pattern.replace(/\\/g, "/");
+  const escaped = normalized
+    .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+    .replace(/\*\*/g, "{{DOUBLESTAR}}")
+    .replace(/\*/g, "[^/]*")
+    .replace(/{{DOUBLESTAR}}/g, ".*");
+  return new RegExp(`^${escaped}$`);
+}
+
+function loadPatterns() {
+  const configPath = resolve(root, ".github/PROTECTED_FILES.json");
+  const config = JSON.parse(readFileSync(configPath, "utf8"));
+  if (!Array.isArray(config.patterns) || config.patterns.length === 0) {
+    throw new Error(".github/PROTECTED_FILES.json must define a non-empty patterns array");
+  }
+  return config.patterns.map(globToRegExp);
+}
+
+function resolveBaseRef() {
+  if (process.env.GITHUB_BASE_REF) {
+    return process.env.GITHUB_BASE_REF;
+  }
+  if (process.env.PROTECTED_FILES_BASE_REF) {
+    return process.env.PROTECTED_FILES_BASE_REF;
+  }
+  return "chore/v1.7-repo-org";
+}
+
+function getChangedFiles(baseRef) {
+  const remoteRef = `origin/${baseRef}`;
+  const commands = [
+    `git diff ${remoteRef}...HEAD --name-only`,
+    "git diff HEAD~1...HEAD --name-only",
+  ];
+
+  for (const command of commands) {
+    try {
+      const output = execSync(command, {
+        cwd: root,
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+      }).trim();
+      if (output) {
+        return output.split(/\r?\n/).filter(Boolean);
+      }
+    } catch {
+      // Try the next diff strategy.
+    }
+  }
+
+  return [];
+}
+
+function findViolations(changedFiles, patterns) {
+  const violations = [];
+  for (const file of changedFiles) {
+    const normalized = file.replace(/\\/g, "/");
+    if (patterns.some(pattern => pattern.test(normalized))) {
+      violations.push(normalized);
+    }
+  }
+  return [...new Set(violations)].sort();
+}
+
+const patterns = loadPatterns();
+const baseRef = resolveBaseRef();
+const changedFiles = getChangedFiles(baseRef);
+const violations = findViolations(changedFiles, patterns);
+
+if (violations.length === 0) {
+  console.log(`${GREEN}[lock-files] OK${RESET}`);
+  process.exit(0);
+}
+
+console.error(`${RED}[lock-files] VIOLATION${RESET}`);
+console.error(`Base ref: ${baseRef}`);
+console.error("Protected files changed:");
+for (const file of violations) {
+  console.error(`  - ${file}`);
+}
+console.error("See CONTRIBUTING.md § Protected Files for the override process.");
+process.exit(1);

--- a/scripts/check-protected-files.mjs
+++ b/scripts/check-protected-files.mjs
@@ -33,23 +33,22 @@ export function loadPatterns() {
   return config.patterns.map(globToRegExp);
 }
 
-export function resolveBaseRef() {
-  const baseRef =
-    process.env.GITHUB_BASE_REF ??
-    process.env.PROTECTED_FILES_BASE_REF ??
-    "master";
-
-  if (!/^[0-9A-Za-z._/-]+$/.test(baseRef)) {
-    throw new Error(`Invalid base ref: ${baseRef}`);
+export function resolveBaseSha() {
+  const baseSha = process.env.BASE_SHA ?? process.env.PROTECTED_FILES_BASE_SHA;
+  if (!baseSha) {
+    throw new Error(
+      "BASE_SHA is required (set automatically in CI; for local runs set PROTECTED_FILES_BASE_SHA to a full commit SHA)"
+    );
   }
-
-  return baseRef;
+  if (!/^[0-9a-f]{40}$/i.test(baseSha)) {
+    throw new Error(`Invalid base SHA: ${baseSha}`);
+  }
+  return baseSha;
 }
 
-export function getChangedFiles(baseRef) {
-  const remoteRef = `origin/${baseRef}`;
+export function getChangedFiles(baseSha) {
   try {
-    const output = execSync(`git diff ${remoteRef}...HEAD --name-only`, {
+    const output = execSync(`git diff ${baseSha} HEAD --name-only`, {
       cwd: root,
       encoding: "utf8",
       stdio: ["ignore", "pipe", "pipe"],
@@ -57,7 +56,7 @@ export function getChangedFiles(baseRef) {
     return output ? output.split(/\r?\n/).filter(Boolean) : [];
   } catch (err) {
     throw new Error(
-      `[lock-files] git diff failed for base ref "${baseRef}": ${err.message}`
+      `[lock-files] git diff failed for base SHA "${baseSha}": ${err.message}`
     );
   }
 }
@@ -75,7 +74,7 @@ export function findViolations(changedFiles, patterns) {
 
 export function runCheck({
   loadPatternsFn = loadPatterns,
-  resolveBaseRefFn = resolveBaseRef,
+  resolveBaseShaFn = resolveBaseSha,
   getChangedFilesFn = getChangedFiles,
   findViolationsFn = findViolations,
   log = (msg) => console.log(msg),
@@ -83,8 +82,8 @@ export function runCheck({
   exit = (code) => process.exit(code),
 } = {}) {
   const patterns = loadPatternsFn();
-  const baseRef = resolveBaseRefFn();
-  const changedFiles = getChangedFilesFn(baseRef);
+  const baseSha = resolveBaseShaFn();
+  const changedFiles = getChangedFilesFn(baseSha);
   const violations = findViolationsFn(changedFiles, patterns);
 
   if (violations.length === 0) {
@@ -94,7 +93,7 @@ export function runCheck({
   }
 
   error(`${RED}[lock-files] VIOLATION${RESET}`);
-  error(`Base ref: ${baseRef}`);
+  error(`Base SHA: ${baseSha}`);
   error("Protected files changed:");
   for (const file of violations) {
     error(`  - ${file}`);

--- a/scripts/check-protected-files.mjs
+++ b/scripts/check-protected-files.mjs
@@ -6,14 +6,15 @@ import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-const __dir = dirname(fileURLToPath(import.meta.url));
+const __file = fileURLToPath(import.meta.url);
+const __dir = dirname(__file);
 const root = resolve(__dir, "..");
 
 const GREEN = "\x1b[32m";
 const RED = "\x1b[31m";
 const RESET = "\x1b[0m";
 
-function globToRegExp(pattern) {
+export function globToRegExp(pattern) {
   const normalized = pattern.replace(/\\/g, "/");
   const escaped = normalized
     .replace(/[.+^${}()|[\]\\]/g, "\\$&")
@@ -23,7 +24,7 @@ function globToRegExp(pattern) {
   return new RegExp(`^${escaped}$`);
 }
 
-function loadPatterns() {
+export function loadPatterns() {
   const configPath = resolve(root, ".github/PROTECTED_FILES.json");
   const config = JSON.parse(readFileSync(configPath, "utf8"));
   if (!Array.isArray(config.patterns) || config.patterns.length === 0) {
@@ -32,7 +33,7 @@ function loadPatterns() {
   return config.patterns.map(globToRegExp);
 }
 
-function resolveBaseRef() {
+export function resolveBaseRef() {
   const baseRef =
     process.env.GITHUB_BASE_REF ??
     process.env.PROTECTED_FILES_BASE_REF ??
@@ -45,31 +46,23 @@ function resolveBaseRef() {
   return baseRef;
 }
 
-function getChangedFiles(baseRef) {
+export function getChangedFiles(baseRef) {
   const remoteRef = `origin/${baseRef}`;
-  const commands = [
-    `git diff ${remoteRef}...HEAD --name-only`,
-    "git diff HEAD~1...HEAD --name-only",
-  ];
-
-  for (const command of commands) {
-    try {
-      const output = execSync(command, {
-        cwd: root,
-        encoding: "utf8",
-        stdio: ["ignore", "pipe", "pipe"],
-      }).trim();
-
-      return output ? output.split(/\r?\n/).filter(Boolean) : [];
-    } catch {
-      // Try the next diff strategy.
-    }
+  try {
+    const output = execSync(`git diff ${remoteRef}...HEAD --name-only`, {
+      cwd: root,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    }).trim();
+    return output ? output.split(/\r?\n/).filter(Boolean) : [];
+  } catch (err) {
+    throw new Error(
+      `[lock-files] git diff failed for base ref "${baseRef}": ${err.message}`
+    );
   }
-
-  throw new Error(`[lock-files] Unable to determine changed files (base ref: ${baseRef})`);
 }
 
-function findViolations(changedFiles, patterns) {
+export function findViolations(changedFiles, patterns) {
   const violations = [];
   for (const file of changedFiles) {
     const normalized = file.replace(/\\/g, "/");
@@ -80,21 +73,36 @@ function findViolations(changedFiles, patterns) {
   return [...new Set(violations)].sort();
 }
 
-const patterns = loadPatterns();
-const baseRef = resolveBaseRef();
-const changedFiles = getChangedFiles(baseRef);
-const violations = findViolations(changedFiles, patterns);
+export function runCheck({
+  loadPatternsFn = loadPatterns,
+  resolveBaseRefFn = resolveBaseRef,
+  getChangedFilesFn = getChangedFiles,
+  findViolationsFn = findViolations,
+  log = (msg) => console.log(msg),
+  error = (msg) => console.error(msg),
+  exit = (code) => process.exit(code),
+} = {}) {
+  const patterns = loadPatternsFn();
+  const baseRef = resolveBaseRefFn();
+  const changedFiles = getChangedFilesFn(baseRef);
+  const violations = findViolationsFn(changedFiles, patterns);
 
-if (violations.length === 0) {
-  console.log(`${GREEN}[lock-files] OK${RESET}`);
-  process.exit(0);
+  if (violations.length === 0) {
+    log(`${GREEN}[lock-files] OK${RESET}`);
+    exit(0);
+    return;
+  }
+
+  error(`${RED}[lock-files] VIOLATION${RESET}`);
+  error(`Base ref: ${baseRef}`);
+  error("Protected files changed:");
+  for (const file of violations) {
+    error(`  - ${file}`);
+  }
+  error("See CONTRIBUTING.md § Protected Files for the override process.");
+  exit(1);
 }
 
-console.error(`${RED}[lock-files] VIOLATION${RESET}`);
-console.error(`Base ref: ${baseRef}`);
-console.error("Protected files changed:");
-for (const file of violations) {
-  console.error(`  - ${file}`);
+if (resolve(process.argv[1] ?? "") === __file) {
+  runCheck();
 }
-console.error("See CONTRIBUTING.md § Protected Files for the override process.");
-process.exit(1);

--- a/scripts/check-protected-files.mjs
+++ b/scripts/check-protected-files.mjs
@@ -1,7 +1,7 @@
 /**
  * CI gate: fail when a PR touches paths listed in .github/PROTECTED_FILES.json.
  */
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -48,7 +48,7 @@ export function resolveBaseSha() {
 
 export function getChangedFiles(baseSha) {
   try {
-    const output = execSync(`git diff ${baseSha} HEAD --name-only`, {
+    const output = execFileSync("git", ["diff", baseSha, "HEAD", "--name-only"], {
       cwd: root,
       encoding: "utf8",
       stdio: ["ignore", "pipe", "pipe"],

--- a/scripts/check-protected-files.mjs
+++ b/scripts/check-protected-files.mjs
@@ -33,13 +33,16 @@ function loadPatterns() {
 }
 
 function resolveBaseRef() {
-  if (process.env.GITHUB_BASE_REF) {
-    return process.env.GITHUB_BASE_REF;
+  const baseRef =
+    process.env.GITHUB_BASE_REF ??
+    process.env.PROTECTED_FILES_BASE_REF ??
+    "master";
+
+  if (!/^[0-9A-Za-z._/-]+$/.test(baseRef)) {
+    throw new Error(`Invalid base ref: ${baseRef}`);
   }
-  if (process.env.PROTECTED_FILES_BASE_REF) {
-    return process.env.PROTECTED_FILES_BASE_REF;
-  }
-  return "chore/v1.7-repo-org";
+
+  return baseRef;
 }
 
 function getChangedFiles(baseRef) {
@@ -56,15 +59,14 @@ function getChangedFiles(baseRef) {
         encoding: "utf8",
         stdio: ["ignore", "pipe", "pipe"],
       }).trim();
-      if (output) {
-        return output.split(/\r?\n/).filter(Boolean);
-      }
+
+      return output ? output.split(/\r?\n/).filter(Boolean) : [];
     } catch {
       // Try the next diff strategy.
     }
   }
 
-  return [];
+  throw new Error(`[lock-files] Unable to determine changed files (base ref: ${baseRef})`);
 }
 
 function findViolations(changedFiles, patterns) {

--- a/test/check-protected-files.spec.js
+++ b/test/check-protected-files.spec.js
@@ -40,7 +40,7 @@ describe("globToRegExp", function () {
     assert.isFalse(re.test("XgithubYPROTECTED_FILESZjson"));
   });
 
-  it("normalises Windows backslashes in the pattern", function () {
+  it("normalizes Windows backslashes in the pattern", function () {
     const re = globToRegExp("src\\modules.ts");
     assert.isTrue(re.test("src/modules.ts"));
   });
@@ -87,7 +87,7 @@ describe("findViolations", function () {
     assert.deepEqual(violations, ["package.json"]);
   });
 
-  it("normalises Windows backslashes in file paths", function () {
+  it("normalizes Windows backslashes in file paths", function () {
     const violations = findViolations(["src\\modules.ts"], patterns);
     assert.deepEqual(violations, ["src/modules.ts"]);
   });

--- a/test/check-protected-files.spec.js
+++ b/test/check-protected-files.spec.js
@@ -9,6 +9,8 @@ import {
   runCheck,
 } from "../scripts/check-protected-files.mjs";
 
+const FAKE_SHA = "a".repeat(40);
+
 // ─── globToRegExp ────────────────────────────────────────────────────────────
 
 describe("globToRegExp", function () {
@@ -118,7 +120,7 @@ describe("runCheck", function () {
     const cap = makeCapture();
     runCheck({
       loadPatternsFn: () => [globToRegExp("package.json")],
-      resolveBaseRefFn: () => "master",
+      resolveBaseShaFn: () => FAKE_SHA,
       getChangedFilesFn: () => ["src/foo.ts", "README.md"],
       findViolationsFn: () => [],
       log: cap.log,
@@ -133,9 +135,10 @@ describe("runCheck", function () {
 
   it("exits 1 and reports violations when protected files are changed", function () {
     const cap = makeCapture();
+    const sha = "b".repeat(40);
     runCheck({
       loadPatternsFn: () => [globToRegExp("package.json")],
-      resolveBaseRefFn: () => "chore/v1.7-repo-org",
+      resolveBaseShaFn: () => sha,
       getChangedFilesFn: () => ["package.json", "src/foo.ts"],
       findViolationsFn: () => ["package.json"],
       log: cap.log,
@@ -145,7 +148,7 @@ describe("runCheck", function () {
 
     assert.equal(cap.exitCode, 1);
     assert.isTrue(cap.errors.some((e) => e.includes("[lock-files] VIOLATION")));
-    assert.isTrue(cap.errors.some((e) => e.includes("Base ref: chore/v1.7-repo-org")));
+    assert.isTrue(cap.errors.some((e) => e.includes(`Base SHA: ${sha}`)));
     assert.isTrue(cap.errors.some((e) => e.includes("package.json")));
     assert.isTrue(cap.errors.some((e) => e.includes("CONTRIBUTING.md")));
   });
@@ -154,7 +157,7 @@ describe("runCheck", function () {
     const cap = makeCapture();
     runCheck({
       loadPatternsFn: () => [],
-      resolveBaseRefFn: () => "master",
+      resolveBaseShaFn: () => FAKE_SHA,
       getChangedFilesFn: () => [],
       findViolationsFn: () => ["package.json", "src/modules.ts"],
       log: cap.log,
@@ -179,17 +182,17 @@ describe("runCheck", function () {
     );
   });
 
-  it("propagates errors thrown by resolveBaseRef", function () {
+  it("propagates errors thrown by resolveBaseSha", function () {
     assert.throws(
       () =>
         runCheck({
           loadPatternsFn: () => [],
-          resolveBaseRefFn: () => {
-            throw new Error("invalid ref");
+          resolveBaseShaFn: () => {
+            throw new Error("missing SHA");
           },
           exit: () => {},
         }),
-      /invalid ref/
+      /missing SHA/
     );
   });
 
@@ -198,7 +201,7 @@ describe("runCheck", function () {
       () =>
         runCheck({
           loadPatternsFn: () => [],
-          resolveBaseRefFn: () => "master",
+          resolveBaseShaFn: () => FAKE_SHA,
           getChangedFilesFn: () => {
             throw new Error("git diff failed");
           },

--- a/test/check-protected-files.spec.js
+++ b/test/check-protected-files.spec.js
@@ -6,6 +6,7 @@ import { assert } from "chai";
 import {
   globToRegExp,
   findViolations,
+  resolveBaseSha,
   runCheck,
 } from "../scripts/check-protected-files.mjs";
 
@@ -96,6 +97,42 @@ describe("findViolations", function () {
 
   it("returns empty array when changedFiles is empty", function () {
     assert.deepEqual(findViolations([], patterns), []);
+  });
+});
+
+// ─── resolveBaseSha ──────────────────────────────────────────────────────────
+
+describe("resolveBaseSha", function () {
+  const VALID_SHA = "a".repeat(40);
+
+  afterEach(function () {
+    delete process.env.BASE_SHA;
+    delete process.env.PROTECTED_FILES_BASE_SHA;
+  });
+
+  it("returns BASE_SHA when set to a valid 40-char hex string", function () {
+    process.env.BASE_SHA = VALID_SHA;
+    assert.equal(resolveBaseSha(), VALID_SHA);
+  });
+
+  it("falls back to PROTECTED_FILES_BASE_SHA when BASE_SHA is absent", function () {
+    const fallback = "b".repeat(40);
+    process.env.PROTECTED_FILES_BASE_SHA = fallback;
+    assert.equal(resolveBaseSha(), fallback);
+  });
+
+  it("throws when neither env var is set", function () {
+    assert.throws(() => resolveBaseSha(), /BASE_SHA is required/);
+  });
+
+  it("throws when the SHA is not a 40-char hex string", function () {
+    process.env.BASE_SHA = "not-a-sha";
+    assert.throws(() => resolveBaseSha(), /Invalid base SHA/);
+  });
+
+  it("throws when the SHA is shorter than 40 hex chars", function () {
+    process.env.BASE_SHA = "a".repeat(39);
+    assert.throws(() => resolveBaseSha(), /Invalid base SHA/);
   });
 });
 

--- a/test/check-protected-files.spec.js
+++ b/test/check-protected-files.spec.js
@@ -1,0 +1,210 @@
+/**
+ * Unit tests for scripts/check-protected-files.mjs.
+ * All runs are mocked — no real git commands or file I/O.
+ */
+import { assert } from "chai";
+import {
+  globToRegExp,
+  findViolations,
+  runCheck,
+} from "../scripts/check-protected-files.mjs";
+
+// ─── globToRegExp ────────────────────────────────────────────────────────────
+
+describe("globToRegExp", function () {
+  it("matches an exact path", function () {
+    const re = globToRegExp("package.json");
+    assert.isTrue(re.test("package.json"));
+    assert.isFalse(re.test("src/package.json"));
+    assert.isFalse(re.test("package.json.bak"));
+  });
+
+  it("matches ** wildcard across path segments", function () {
+    const re = globToRegExp("test/helpers/**");
+    assert.isTrue(re.test("test/helpers/foo.js"));
+    assert.isTrue(re.test("test/helpers/sub/bar.js"));
+    assert.isFalse(re.test("test/foo.js"));
+    assert.isFalse(re.test("test/helpersfoo.js"));
+  });
+
+  it("matches * wildcard within a single path segment", function () {
+    const re = globToRegExp("scripts/*.mjs");
+    assert.isTrue(re.test("scripts/check-public-api.mjs"));
+    assert.isFalse(re.test("scripts/sub/check.mjs"));
+    assert.isFalse(re.test("scripts/check.js"));
+  });
+
+  it("escapes regex special characters in literal parts", function () {
+    const re = globToRegExp(".github/PROTECTED_FILES.json");
+    assert.isTrue(re.test(".github/PROTECTED_FILES.json"));
+    assert.isFalse(re.test("XgithubYPROTECTED_FILESZjson"));
+  });
+
+  it("normalises Windows backslashes in the pattern", function () {
+    const re = globToRegExp("src\\modules.ts");
+    assert.isTrue(re.test("src/modules.ts"));
+  });
+});
+
+// ─── findViolations ──────────────────────────────────────────────────────────
+
+describe("findViolations", function () {
+  const patterns = [
+    globToRegExp("package.json"),
+    globToRegExp("test/helpers/**"),
+    globToRegExp("src/modules.ts"),
+  ];
+
+  it("returns an empty array when no changed file matches", function () {
+    assert.deepEqual(findViolations(["src/other.ts", "README.md"], patterns), []);
+  });
+
+  it("returns only the matching files", function () {
+    const violations = findViolations(
+      ["src/modules.ts", "src/other.ts", "README.md"],
+      patterns
+    );
+    assert.deepEqual(violations, ["src/modules.ts"]);
+  });
+
+  it("returns multiple violations sorted", function () {
+    const violations = findViolations(
+      ["src/modules.ts", "package.json", "test/helpers/foo.js"],
+      patterns
+    );
+    assert.deepEqual(violations, [
+      "package.json",
+      "src/modules.ts",
+      "test/helpers/foo.js",
+    ]);
+  });
+
+  it("deduplicates repeated file paths", function () {
+    const violations = findViolations(
+      ["package.json", "package.json", "package.json"],
+      patterns
+    );
+    assert.deepEqual(violations, ["package.json"]);
+  });
+
+  it("normalises Windows backslashes in file paths", function () {
+    const violations = findViolations(["src\\modules.ts"], patterns);
+    assert.deepEqual(violations, ["src/modules.ts"]);
+  });
+
+  it("returns empty array when changedFiles is empty", function () {
+    assert.deepEqual(findViolations([], patterns), []);
+  });
+});
+
+// ─── runCheck (main orchestration) ──────────────────────────────────────────
+
+describe("runCheck", function () {
+  function makeCapture() {
+    const logs = [];
+    const errors = [];
+    let exitCode = null;
+    return {
+      log: (msg) => logs.push(msg),
+      error: (msg) => errors.push(msg),
+      exit: (code) => { exitCode = code; },
+      get logs() { return logs; },
+      get errors() { return errors; },
+      get exitCode() { return exitCode; },
+    };
+  }
+
+  it("exits 0 and logs OK when there are no violations", function () {
+    const cap = makeCapture();
+    runCheck({
+      loadPatternsFn: () => [globToRegExp("package.json")],
+      resolveBaseRefFn: () => "master",
+      getChangedFilesFn: () => ["src/foo.ts", "README.md"],
+      findViolationsFn: () => [],
+      log: cap.log,
+      error: cap.error,
+      exit: cap.exit,
+    });
+
+    assert.equal(cap.exitCode, 0);
+    assert.isTrue(cap.logs.some((l) => l.includes("[lock-files] OK")));
+    assert.isEmpty(cap.errors);
+  });
+
+  it("exits 1 and reports violations when protected files are changed", function () {
+    const cap = makeCapture();
+    runCheck({
+      loadPatternsFn: () => [globToRegExp("package.json")],
+      resolveBaseRefFn: () => "chore/v1.7-repo-org",
+      getChangedFilesFn: () => ["package.json", "src/foo.ts"],
+      findViolationsFn: () => ["package.json"],
+      log: cap.log,
+      error: cap.error,
+      exit: cap.exit,
+    });
+
+    assert.equal(cap.exitCode, 1);
+    assert.isTrue(cap.errors.some((e) => e.includes("[lock-files] VIOLATION")));
+    assert.isTrue(cap.errors.some((e) => e.includes("Base ref: chore/v1.7-repo-org")));
+    assert.isTrue(cap.errors.some((e) => e.includes("package.json")));
+    assert.isTrue(cap.errors.some((e) => e.includes("CONTRIBUTING.md")));
+  });
+
+  it("lists every violation file individually", function () {
+    const cap = makeCapture();
+    runCheck({
+      loadPatternsFn: () => [],
+      resolveBaseRefFn: () => "master",
+      getChangedFilesFn: () => [],
+      findViolationsFn: () => ["package.json", "src/modules.ts"],
+      log: cap.log,
+      error: cap.error,
+      exit: cap.exit,
+    });
+
+    assert.isTrue(cap.errors.some((e) => e.includes("package.json")));
+    assert.isTrue(cap.errors.some((e) => e.includes("src/modules.ts")));
+  });
+
+  it("propagates errors thrown by loadPatterns", function () {
+    assert.throws(
+      () =>
+        runCheck({
+          loadPatternsFn: () => {
+            throw new Error("bad config file");
+          },
+          exit: () => {},
+        }),
+      /bad config file/
+    );
+  });
+
+  it("propagates errors thrown by resolveBaseRef", function () {
+    assert.throws(
+      () =>
+        runCheck({
+          loadPatternsFn: () => [],
+          resolveBaseRefFn: () => {
+            throw new Error("invalid ref");
+          },
+          exit: () => {},
+        }),
+      /invalid ref/
+    );
+  });
+
+  it("propagates errors thrown by getChangedFiles (fail closed)", function () {
+    assert.throws(
+      () =>
+        runCheck({
+          loadPatternsFn: () => [],
+          resolveBaseRefFn: () => "master",
+          getChangedFilesFn: () => {
+            throw new Error("git diff failed");
+          },
+          exit: () => {},
+        }),
+      /git diff failed/
+    );
+  });
+});


### PR DESCRIPTION
## What

Adds a `lock-files` CI gate to prevent PRs from modifying a configured set of protected paths without explicit owner involvement, and documents the policy for contributors.

- **`.github/workflows/lock-files.yml`** — PR-triggered workflow that runs the protected-file check on every open/sync/reopen event. Uses `github.event.pull_request.base.sha` to fetch only the single base commit the PR branched from (`git fetch --depth=1`), then diffs from that exact SHA to `HEAD`.
- **`.github/PROTECTED_FILES.json`** — Defines the protected path patterns enforced by the gate. The file protects itself and the check script to prevent silent bypass.
- **`scripts/check-protected-files.mjs`** — Implements protected-path detection via `git diff <base_sha> HEAD --name-only` using `execFileSync` with an argument array (no shell interpolation). Resolves the base SHA from the `BASE_SHA` env var (set by CI) or `PROTECTED_FILES_BASE_SHA` (for local runs); validates it as a 40-char hex string. All helper functions and the main orchestration are exported via `runCheck()` with injectable dependencies for unit testing. Entry-point execution is guarded so the script does not run on `import`.
- **`CONTRIBUTING.md`** — Documents protected paths, their rationale, and the override process (only `@jml6m` can merge changes touching protected files).
- **`test/check-protected-files.spec.js`** — 17 unit tests covering `globToRegExp`, `findViolations`, and the full `runCheck` orchestration block using mocked dependencies (no real git or file I/O).

## Related issues

## Why

Prevent accidental or unreviewed changes to high-impact paths (public API entry point, contract test helpers, build config, the gate itself) from landing without explicit project-owner sign-off.

## How

- The workflow fetches only the single base commit using `git fetch --depth=1 origin ${{ github.event.pull_request.base.sha }}` — no full history required. This precisely covers "the point in time the PR branched from the target branch + all the changes on the PR."
- `getChangedFiles` uses `execFileSync("git", ["diff", baseSha, "HEAD", "--name-only"])` — single command, argument array form (no shell interpolation of the SHA), fail-closed on any git error.
- `runCheck()` accepts injectable `loadPatternsFn`, `resolveBaseShaFn`, `getChangedFilesFn`, `findViolationsFn`, `log`, `error`, and `exit` to enable deterministic unit testing.
- `.github/PROTECTED_FILES.json` and `scripts/check-protected-files.mjs` are listed as protected entries so the gate cannot be silently weakened.

## How tested

- [x] `npm ci`
- [x] `npm test`
- [ ] Manual smoke test (if user-facing)

## Checklist

- [x] PR targets the current version integration branch (e.g. `chore/v1.7-repo-org`), not `master`, unless this is the release merge PR or an approved stable hotfix
- [x] Changes are focused and optimized
- [x] Tests added or updated for new/changed behavior
- [x] Test Coverage maintained (see [.c8rc.json](../.c8rc.json))
- [x] No version bump in [package.json](../package.json)
- [ ] [README.md](../README.md) if needed, but a request for approval must be made to the project admin on the PR or in the agent chat