### PR TITLE
chore(release): bump version to 1.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fas-js",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fas-js",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "@eslint/js": "^9.39.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fas-js",
   "description": "Finate State Automata JS Solutions",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "type": "module",
   "main": "./lib/index.cjs",
   "module": "./lib/index.js",
@@ -29,7 +29,6 @@
     "typecheck": "tsc --noEmit",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
-
     "free-port": "node scripts/free-port.mjs 3200",
     "preserve:demo": "node scripts/free-port.mjs 3200",
     "serve:demo": "node scripts/serve-demo.mjs",


### PR DESCRIPTION
## What

Human-initiated version bump `1.6.0` → `1.7.0` for the v1.7 release.

## Changes

- `package.json`, `package-lock.json` version → `1.7.0`. No source or behavior changes.

## Notes

Final step on the integration branch before merging the release PR (#256) into `master` and tagging `v1.7.0`. `package.json` is no longer in the protected set, so `lock-files` is not expected to fire.