### PR TITLE
fix(release): restore 1.7.0 version + fix publish.yml build order

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,6 +25,9 @@ jobs:
       # Use recent npm for OIDC provenance support (see ci.yml for rationale).
       - run: npm install -g npm@^11.5.1
       - run: npm ci
+      # Build before the security gate: check:security -> check-public-api.mjs
+      # reads lib/index.d.ts, so the artifact must exist first.
+      - run: npm run build
       - run: node scripts/check-package-scripts.mjs
       - run: npm run check:security
       - run: npm publish --provenance --access public

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
       - run: npm ci
       # Build before the security gate: check:security -> check-public-api.mjs
       # reads lib/index.d.ts, so the artifact must exist first.
-      - run: npm run build
       - run: node scripts/check-package-scripts.mjs
+      - run: npm run build
       - run: npm run check:security
       - run: npm publish --provenance --access public

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fas-js",
   "description": "Finate State Automata JS Solutions",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "type": "module",
   "main": "./lib/index.cjs",
   "module": "./lib/index.js",


### PR DESCRIPTION
## What

Recovers the v1.7.0 release after the publish run failed ([run](https://github.com/jml6m/fas-js/actions/runs/27892887731)). **Nothing was published** — npm is still at 1.6.0; the run died in `check:security`, before the `npm publish` upload.

## Root causes

1. **Version reverted to 1.6.0.** After #264 set `1.7.0`, later integration-branch housekeeping (`f497083` + a pull-merge) reverted `package.json` back to `1.6.0` (the lockfile stayed `1.7.0`, leaving master inconsistent). #256 then shipped `package.json` at 1.6.0.
2. **`publish.yml` build-order bug.** `npm run check:security` → `check-public-api.mjs` reads `lib/index.d.ts`, but there was no `npm run build` before it → `ENOENT` on every publish.

## Changes

- `package.json` version `1.6.0` → `1.7.0` (now consistent with the lockfile).
- `publish.yml`: add `npm run build` after `npm ci`, before the gate steps.

## How tested

- `test (18/20/22)` on this PR.
- Post-merge: publish via `workflow_dispatch` on `master`.

## Merge

Targets `master` (recovery hotfix). Touches protected `publish.yml` → `lock-files` fails by design (advisory). Owner override for the master approval requirement, as with the rest of v1.7.