### PR TITLE
chore: override-free release process (#275)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -43,6 +43,11 @@ For unsupervised runs (e.g. automated fixes):
 - New public API features remain scheduled for **v2**; release lines ship UX, tests, docs, and internal language tooling.
 - See [`CONTRIBUTING.md`](../CONTRIBUTING.md) for contributor-facing details.
 
+**Branch policy (enforced):**
+
+- **Topic work never targets `master` directly.** Every change lands on a short-lived topic branch that PRs into the **current version integration branch** (`chore/vX.Y-*`). `master` only ever receives the single **integration → `master`** release PR (plus Dependabot action bumps). Enforced by [`release-base-guard`](./workflows/release-base-guard.yml): a PR into `master` whose head is not `chore/v*`, `v*`, or `dependabot/*` fails.
+- The integration → `master` release PR is **approved automatically** by a trusted GitHub App when a maintainer applies the **`release`** label — see [`release-auto-approve`](./workflows/release-auto-approve.yml) and [`RELEASING.md`](../RELEASING.md). This satisfies the `main` ruleset's required approval **without a self-approve and without relaxing the ruleset**; required status checks still gate the merge.
+
 **Ref & tag hygiene:**
 
 - **Auto-delete on merge** is enabled — merged topic branches are removed automatically. Keep them short-lived; delete abandoned ones.

--- a/.github/workflows/release-auto-approve.yml
+++ b/.github/workflows/release-auto-approve.yml
@@ -1,0 +1,55 @@
+name: Release PR Auto-Approve
+
+# Eliminates the manual `main`-ruleset relaxation for the release PR (issue #275).
+#
+# When a maintainer applies the `release` label to an integration → master PR,
+# a trusted GitHub App submits an approving review. This satisfies the `main`
+# ruleset's "1 approving review" requirement WITHOUT a human self-approving and
+# WITHOUT temporarily disabling the ruleset. Required status checks still gate
+# the actual merge, and the label is the maintainer's explicit "this is ready"
+# signal (only users with write/triage access can apply labels).
+#
+# One-time manual setup (see RELEASING.md):
+#   1. Create a GitHub App with repository permission `Pull requests: write`.
+#   2. Install it on this repository.
+#   3. Store its credentials as repo secrets:
+#        RELEASE_APPROVER_APP_ID   = the App's numeric id
+#        RELEASE_APPROVER_APP_KEY  = the App's PEM private key
+#   The App identity must differ from the PR author (GitHub rejects self-approval).
+#
+# NOTE: pin actions/create-github-app-token to a commit SHA (repo policy pins all
+# actions) before the `main` ruleset is re-enabled.
+
+on:
+  pull_request:
+    types: [labeled]
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  approve:
+    # Only for the release label on an integration/release branch PR into master.
+    if: >-
+      github.event.label.name == 'release' &&
+      (startsWith(github.event.pull_request.head.ref, 'chore/v') ||
+       startsWith(github.event.pull_request.head.ref, 'v'))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mint a GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1 # TODO: SHA-pin before re-enabling rulesets
+        with:
+          app-id: ${{ secrets.RELEASE_APPROVER_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APPROVER_APP_KEY }}
+
+      - name: Approve the release PR
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh pr review "$PR" --repo "$REPO" --approve \
+            --body "✅ Automated release approval — the \`release\` label was applied to an integration → master PR by a maintainer. Required status checks still gate the merge."

--- a/.github/workflows/release-base-guard.yml
+++ b/.github/workflows/release-base-guard.yml
@@ -1,0 +1,31 @@
+name: Release Base Guard
+
+# Enforces the branch policy: topic work never targets `master` directly.
+# Only the integration → master release PR (head `chore/v*` / `v*`) — plus
+# Dependabot action bumps — may target `master`. Topic work belongs on the
+# current version integration branch. See AGENTS.md §4 and RELEASING.md.
+
+on:
+  pull_request:
+    types: [opened, reopened, edited, synchronize]
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Only integration/release branches may target master
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          case "$HEAD_REF" in
+            chore/v* | v* | dependabot/*)
+              echo "OK: '$HEAD_REF' is allowed to target master." ;;
+            *)
+              echo "::error::PRs into 'master' must come from a version integration/release branch (chore/v*, v*). Topic work belongs on the current integration branch, not master. Got head '$HEAD_REF'."
+              exit 1 ;;
+          esac

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,11 @@ For unsupervised runs (e.g. automated fixes):
 - New public API features remain scheduled for **v2**; release lines ship UX, tests, docs, and internal language tooling.
 - See [`CONTRIBUTING.md`](CONTRIBUTING.md) for contributor-facing details.
 
+**Branch policy (enforced):**
+
+- **Topic work never targets `master` directly.** Every change lands on a short-lived topic branch that PRs into the **current version integration branch** (`chore/vX.Y-*`). `master` only ever receives the single **integration → `master`** release PR (plus Dependabot action bumps). Enforced by [`release-base-guard`](.github/workflows/release-base-guard.yml): a PR into `master` whose head is not `chore/v*`, `v*`, or `dependabot/*` fails.
+- The integration → `master` release PR is **approved automatically** by a trusted GitHub App when a maintainer applies the **`release`** label — see [`release-auto-approve`](.github/workflows/release-auto-approve.yml) and [`RELEASING.md`](RELEASING.md). This satisfies the `main` ruleset's required approval **without a self-approve and without relaxing the ruleset**; required status checks still gate the merge.
+
 **Ref & tag hygiene:**
 
 - **Auto-delete on merge** is enabled — merged topic branches are removed automatically. Keep them short-lived; delete abandoned ones.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,65 @@
+# Releasing fas-js
+
+The authoritative, override-free runbook for shipping a release. The goal: a
+release needs **no temporary ruleset relaxation and no manual self-approve**.
+See [`AGENTS.md`](./AGENTS.md) §4 for the branch policy this enforces.
+
+## Branch model
+
+```
+topic branch ──PR──▶ version integration branch (chore/vX.Y-*) ──release PR──▶ master ──tag vX.Y.Z──▶ npm
+```
+
+- **One active integration branch per release**, branched from `master`, named `chore/vX.Y-*` (e.g. `chore/v1.8-hygiene`). Per [`AGENTS.md`](./AGENTS.md) §4, minor lines ship UX, tests, docs, and internal tooling; public API features are reserved for v2.
+- **Topic work never targets `master` directly** — it PRs into the current integration branch. Enforced by [`release-base-guard`](./.github/workflows/release-base-guard.yml).
+- PRs into the integration branch require passing `test (18/20/22)` + `lock-files` but **no approval** (the `next-version-prep-branch` ruleset), so day-to-day work merges without friction.
+
+## 1. Accumulate work on the integration branch
+
+Open topic-branch PRs into `chore/vX.Y-*`. Keep `master`-level coverage (90%) and the public-API contract intact.
+
+## 2. Bump the version (human-initiated)
+
+Agents never bump the version. On a small topic branch into the integration branch:
+
+```bash
+npm version X.Y.Z --no-git-tag-version   # updates package.json + package-lock.json
+```
+
+`package.json` is not in the protected-files set, so this does not trip `lock-files`. PR it into the integration branch and merge.
+
+## 3. Open the release PR (integration → master)
+
+Open a PR from `chore/vX.Y-*` into `master`. [`release-base-guard`](./.github/workflows/release-base-guard.yml) confirms the head is an integration/release branch.
+
+## 4. Approve without relaxing the ruleset
+
+The `main` ruleset requires **1 approving review** (no self-approve, no bypass). Instead of disabling the rule:
+
+- A maintainer applies the **`release`** label to the PR.
+- [`release-auto-approve`](./.github/workflows/release-auto-approve.yml) submits an approving review via a trusted GitHub App.
+- Required status checks (`test (18/20/22)`, `lock-files`) still gate the merge.
+
+> **One-time setup:** create a GitHub App with `Pull requests: write`, install it on the repo, and store `RELEASE_APPROVER_APP_ID` + `RELEASE_APPROVER_APP_KEY` as repo secrets. The App identity must differ from the PR author. Until this exists, the workflow is inert and the label has no effect.
+
+Squash-merge the release PR once green + approved.
+
+## 5. Tag and publish
+
+```bash
+git tag vX.Y.Z origin/master && git push origin vX.Y.Z
+```
+
+The tag push fires [`publish.yml`](./.github/workflows/publish.yml): OIDC trusted publishing, gated by the `npm` GitHub environment (**requires manual `jml6m` approval** in the Actions UI — branch `workflow_dispatch` is rejected; it must be a tag). Verify success in the CI **publish-step log** (`+ fas-js@X.Y.Z`), not local `npm view` (CDN/proxy lag).
+
+Then: `gh release create vX.Y.Z --target master --generate-notes`.
+
+## 6. Tag immutability (no retag)
+
+Published `vX.Y.Z` tags are **permanent and immutable** — never move or delete one (it would break npm provenance, and the `v*` ruleset blocks it). Fix any post-tag mistake with a **new patch tag** (`vX.Y.(Z+1)`), never by retagging.
+
+## Notes & gotchas
+
+- **Bot-authored PRs** (e.g. Copilot) get workflow runs stuck in `action_required` until a maintainer clicks "Approve and run workflows" — an un-run gate is **not** a pass.
+- **`publish.yml` must `npm run build` before `check:security`** (it reads `lib/index.d.ts`).
+- This runbook is the override-free counterpart to the v1.7 process; remaining hardening is tracked in the release epic (#282).


### PR DESCRIPTION
Part of the release-hardening epic #282. Topic PR into the **`chore/v1.8-hygiene`** integration branch.

Implements the **bot/App auto-approve** mechanism so the eventual `chore/v1.8-hygiene → master` release PR merges **without relaxing the `main` ruleset and without a self-approve**.

## What's here
- [`release-auto-approve.yml`](../.github/workflows/release-auto-approve.yml) — on the `release` label (applied by a maintainer) for a `chore/v*`/`v*` → master PR, a trusted **GitHub App** submits the approving review. Required status checks still gate the merge.
- [`release-base-guard.yml`](../.github/workflows/release-base-guard.yml) — formalizes *topic work never targets master*: PRs into `master` must come from `chore/v*`, `v*`, or `dependabot/*`.
- [`AGENTS.md`](../AGENTS.md) §4 + the Copilot mirror — document the enforced branch policy.
- [`RELEASING.md`](../RELEASING.md) — the override-free release runbook.

## ⚠️ Manual follow-ups before this is live (and before re-enabling rulesets)
1. **Create a GitHub App** (perm `Pull requests: write`), install on the repo, add secrets `RELEASE_APPROVER_APP_ID` + `RELEASE_APPROVER_APP_KEY`. The App identity must differ from the PR author. The auto-approve workflow is **inert** until then.
2. **SHA-pin** `actions/create-github-app-token` (repo policy pins all actions).
3. Add a scoped `bypass_actors` (admin role / the App) to `next-version-prep-branch` so integration branches can be **created** without disabling rules (see #275 comment).

Closes #275. Advances #277, #281.