### PR TITLE
ci: enforce release version correctness (verify-release-version + tag check)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,21 @@ jobs:
           node-version: 20
           registry-url: https://registry.npmjs.org
           cache: npm
+      # Fail-closed publish guard: only a v*.*.* tag push may publish, and the tag
+      # must equal package.json's version. Blocks the v1.7.0-class mismatch (tag and
+      # manifest disagree) and the workflow_dispatch path silently publishing a branch.
+      - name: Verify tag matches package.json version
+        run: |
+          if [ "${GITHUB_REF_TYPE}" != "tag" ]; then
+            echo "::error::Publish must be triggered by a v*.*.* tag push, not ${GITHUB_REF_TYPE} '${GITHUB_REF_NAME}'."
+            exit 1
+          fi
+          PKG_VER="$(node -p "require('./package.json').version")"
+          if [ "${GITHUB_REF_NAME}" != "v${PKG_VER}" ]; then
+            echo "::error::Tag '${GITHUB_REF_NAME}' does not match package.json version 'v${PKG_VER}'."
+            exit 1
+          fi
+          echo "OK: publishing v${PKG_VER} from tag ${GITHUB_REF_NAME}."
       # Use recent npm for OIDC provenance support (see ci.yml for rationale).
       - run: npm install -g npm@^11.5.1
       - run: npm ci

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,8 +27,8 @@ jobs:
       # manifest disagree) and the workflow_dispatch path silently publishing a branch.
       - name: Verify tag matches package.json version
         run: |
-          if [ "${GITHUB_REF_TYPE}" != "tag" ]; then
-            echo "::error::Publish must be triggered by a v*.*.* tag push, not ${GITHUB_REF_TYPE} '${GITHUB_REF_NAME}'."
+          if [ "${GITHUB_EVENT_NAME}" != "push" ] || [ "${GITHUB_REF_TYPE}" != "tag" ]; then
+            echo "::error::Publish must be triggered by a v*.*.* tag push, not ${GITHUB_EVENT_NAME} ${GITHUB_REF_TYPE} '${GITHUB_REF_NAME}'."
             exit 1
           fi
           PKG_VER="$(node -p "require('./package.json').version")"

--- a/.github/workflows/verify-release-version.yml
+++ b/.github/workflows/verify-release-version.yml
@@ -1,0 +1,50 @@
+name: Verify Release Version
+
+# Fail-closed release gate. A release PR (integration/release branch → master) must
+# INCREASE the published version vs `master`. This prevents shipping a stale or
+# unchanged version — the v1.7.0 failure where a reverted bump shipped master as 1.6.0.
+#
+# Required status check on the `main` ruleset → not coverable by the owner's
+# pull-request bypass, so there is no bypass path. Non-release PRs (e.g. Dependabot
+# GitHub Actions bumps) don't change the package version and are skipped (pass).
+
+on:
+  pull_request:
+    types: [opened, reopened, edited, synchronize]
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  verify-release-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Release PR must increase the version vs master
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          # Only release branches carry a version bump; skip everything else.
+          case "$HEAD_REF" in
+            chore/v* | v*) ;;
+            *)
+              echo "Head '$HEAD_REF' is not a release branch — no version bump expected. Skipping."
+              exit 0 ;;
+          esac
+
+          git fetch --no-tags --depth=1 origin master
+          HEAD_VER="$(node -p "require('./package.json').version")"
+          BASE_VER="$(git show FETCH_HEAD:package.json | node -p "JSON.parse(require('node:fs').readFileSync(0,'utf8')).version")"
+          export HEAD_VER BASE_VER
+
+          node -e '
+            const parse = (v) => v.split("-")[0].split(".").map(Number);
+            const [h, b] = [parse(process.env.HEAD_VER), parse(process.env.BASE_VER)];
+            const cmp = (h[0] - b[0]) || (h[1] - b[1]) || (h[2] - b[2]);
+            if (cmp <= 0) {
+              console.error(`::error::Release must increase the version. master=${process.env.BASE_VER}, release=${process.env.HEAD_VER} is not an increase. Bump package.json before merging the release PR.`);
+              process.exit(1);
+            }
+            console.log(`OK: ${process.env.BASE_VER} -> ${process.env.HEAD_VER}`);
+          '

--- a/.github/workflows/verify-release-version.yml
+++ b/.github/workflows/verify-release-version.yml
@@ -21,6 +21,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 20
+          cache: npm
       - name: Release PR must increase the version vs master
         env:
           HEAD_REF: ${{ github.head_ref }}

--- a/.github/workflows/verify-release-version.yml
+++ b/.github/workflows/verify-release-version.yml
@@ -10,7 +10,7 @@ name: Verify Release Version
 
 on:
   pull_request:
-    types: [opened, reopened, edited, synchronize]
+    types: [opened, synchronize]
     branches: [master]
 
 permissions:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -29,6 +29,8 @@ npm version X.Y.Z --no-git-tag-version   # updates package.json + package-lock.j
 
 `package.json` is not in the protected-files set, so this does not trip `lock-files`. PR it into the integration branch and merge.
 
+> **Enforced, not just convention:** the release PR (step 3) is gated by the required [`verify-release-version`](./.github/workflows/verify-release-version.yml) check, which **fails the merge unless `package.json` increases vs `master`**. A forgotten or clobbered bump (the v1.7.0 "shipped as 1.6.0" failure) therefore blocks the release rather than slipping through — so the bump's commit *order* doesn't matter, only that the version is correct at merge time.
+
 ## 3. Open the release PR (integration → master)
 
 Open a PR from `chore/vX.Y-*` into `master`. [`release-base-guard`](./.github/workflows/release-base-guard.yml) confirms the head is an integration/release branch.
@@ -38,11 +40,11 @@ Open a PR from `chore/vX.Y-*` into `master`. [`release-base-guard`](./.github/wo
 The `main` ruleset requires **1 approving review**. Because release PRs are authored under the owner's account, the owner cannot self-approve — so the rule is satisfied another way **without ever relaxing it**:
 
 - The `main` ruleset lists the repository **owner / admin role as a `bypass_actors`** entry, in **"pull requests" bypass mode** (can merge a PR that lacks the required approval; cannot push directly to `master`).
-- The owner squash-merges the integration → `master` release PR directly once all **required status checks** (`test (18/20/22)`, `lock-files`) are green.
+- The owner squash-merges the integration → `master` release PR directly once all **required status checks** (`test (18/20/22)`, `lock-files`, `verify-release-version`) are green.
 
 This keeps the approval requirement fully in force for **every non-owner PR** to `master` (Dependabot, Copilot, contributors — the owner approves those normally, since they aren't self-authored), while letting the sole maintainer ship a release without a self-approve, a second account, a bot App, or a temporary ruleset toggle.
 
-> **One-time ruleset setup:** on the `main` ruleset, add the Repository **admin** role (or `jml6m`) to the **Bypass list** with mode **"Pull requests"**. This is the only standing relaxation and it is scoped to the owner — not a global approval-count change.
+> **One-time ruleset setup:** on the `main` ruleset, (1) add the Repository **admin** role (or `jml6m`) to the **Bypass list** with mode **"Pull requests"** — the only standing relaxation, scoped to the owner, not a global approval-count change; and (2) add **`verify-release-version`** to the required status checks so the version-increase gate cannot be bypassed.
 
 ## 5. Tag and publish
 
@@ -50,7 +52,7 @@ This keeps the approval requirement fully in force for **every non-owner PR** to
 git tag vX.Y.Z origin/master && git push origin vX.Y.Z
 ```
 
-The tag push fires [`publish.yml`](./.github/workflows/publish.yml): OIDC trusted publishing, gated by the `npm` GitHub environment (**requires manual `jml6m` approval** in the Actions UI). Avoid running `workflow_dispatch` for publishing unless `publish.yml` is updated to hard-reject non-tag refs. Verify success in the CI **publish-step log** (`+ fas-js@X.Y.Z`), not local `npm view` (CDN/proxy lag).
+The tag push fires [`publish.yml`](./.github/workflows/publish.yml): OIDC trusted publishing, gated by the `npm` GitHub environment (**requires manual `jml6m` approval** in the Actions UI). Before publishing, the workflow **asserts the tag equals `package.json`'s version and hard-rejects any non-tag trigger** (so a `workflow_dispatch` run cannot silently publish a branch, and a tag/manifest mismatch fails fast). Verify success in the CI **publish-step log** (`+ fas-js@X.Y.Z`), not local `npm view` (CDN/proxy lag).
 
 Then: `gh release create vX.Y.Z --target master --generate-notes`.
 


### PR DESCRIPTION
## What

Enforce **release version correctness** with two fail-closed, no-bypass gates (replaces the brittle "version bump must be the last commit" convention with an outcome-based invariant).

- **`verify-release-version.yml`** — required check on PRs into `master` from a release branch (`chore/v*`/`v*`). Fails the merge unless `package.json` **increases** vs `master`. Non-release heads (e.g. Dependabot Actions bumps) are skipped/pass. This is what would have caught the v1.7.0 failure (a reverted bump shipped `master` as `1.6.0`).
- **`publish.yml`** — before `npm publish`, assert the pushed **tag equals `package.json` version** and **hard-reject any non-tag trigger** (closes the `workflow_dispatch`-publishes-a-branch hole noted in `RELEASING.md`).
- **`RELEASING.md`** — documents both gates and the one-time required-check setup.

## Why

`release-base-guard` only checks the head branch *name*; nothing verifies the version. So today a stale/forgotten/clobbered bump ships silently (v1.7.0). Required status checks are **not** covered by the owner's pull-request bypass, so making `verify-release-version` required is genuinely no-bypass — for everyone, including the owner.

## Notes

- `publish.yml` is a protected file, so this PR trips `lock-files` — expected; it merges into the integration branch via the admin **Always** bypass on `next-version-prep-branch` (no ruleset toggle; that's only needed for the release PR to `master`).
- After merge, add **`verify-release-version`** to the `main` ruleset's required status checks (one-time; documented in `RELEASING.md §4`).

## How tested

- [x] semver-increase logic unit-checked (1.7.0→1.8.0 pass; →1.7.0/1.6.0 block; prerelease handled)
- [x] tag/version + non-tag-reject logic checked
- [x] both workflows validated as YAML
- [x] `npm run docs:lint` clean
