### PR TITLE
chore(release): bump version to 1.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fas-js",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fas-js",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "@eslint/js": "^9.39.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fas-js",
   "description": "Finate State Automata JS Solutions",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "type": "module",
   "main": "./lib/index.cjs",
   "module": "./lib/index.js",


### PR DESCRIPTION
## What

Bump `package.json` + `package-lock.json` to **1.8.0** — the human-initiated release bump (RELEASING.md §2), landed as the final change onto the integration branch before the release PR (#289).

## Why

Required for the v1.8 release. Satisfies the new `verify-release-version` gate on the release PR (1.7.0 → 1.8.0 is an increase).

## Notes

- Only `package.json` / `package-lock.json` change — **not** protected, so this does **not** trip `lock-files`; merges cleanly into the integration branch.
- After this merges, release PR #289 will run `verify-release-version` (passes) and is ready for the documented one-time `lock-files` toggle + owner merge.

## How tested

- [x] `npm version 1.8.0 --no-git-tag-version` updated both manifests to 1.8.0
- [x] No version bump beyond the intended release version