### PR TITLE
(v1.9) Guard-test completeness gate + check-public-api.spec.js (#310)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -118,7 +118,8 @@ TypeScript (`npm run typecheck`) catches **structural** mistakes: wrong argument
 
 ## 🔄 CI / CD
 
-- **CI** (`.github/workflows/ci.yml`): `test` job runs `npm test` (includes `check:security` — public API surface + npm pack gate) on Node 18/20/22; `security` job runs `npm audit --audit-level=high` (fails on high) + `check:security`; uploads coverage to Codecov on the Node 20 matrix entry via `CODECOV_TOKEN`.
+- **CI** (`.github/workflows/ci.yml`): `test` job runs `npm test` (includes `check:security` — guard-test completeness + public API surface + npm pack gate) on Node 18/20/22; `security` job runs `npm audit --audit-level=high` (fails on high) + `check:security`; uploads coverage to Codecov on the Node 20 matrix entry via `CODECOV_TOKEN`.
+- **Guard-test completeness**: `check:security` runs [`scripts/check-guard-tests.mjs`](../scripts/check-guard-tests.mjs) — every `scripts/check-*.mjs` must have a matching `test/check-*.spec.js` or CI fails. Structural, independent of coverage (coverage scope stays `src/**`). See [`docs/coverage-policy.md`](../docs/coverage-policy.md).
 - **Auto-link** (`.github/workflows/auto-link-issue.yml`): prepends `Closes #N` when branch name starts with `N-`.
 - **Dead-code check**: `security` job runs `npm run health:dead` (knip, non-blocking warning); the hard failure is `npm run health:dead:strict` in [`publish.yml`](workflows/publish.yml).
 - **Publish** (`.github/workflows/publish.yml`): triggers on `v*.*.*` tags (and can also be run via `workflow_dispatch`); uses OIDC trusted publishing (no NPM_TOKEN needed); gated by the `npm` GitHub environment (requires manual approval).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -184,8 +184,9 @@ TypeScript (`npm run typecheck`) catches **structural** mistakes: wrong argument
 
 ## 🔄 CI / CD
 
-- **CI** (`.github/workflows/ci.yml`): `test` job runs `npm test` (includes `check:security` — public API surface + npm pack gate) on Node 18/20/22; `security` job runs `npm audit --audit-level=high` (fails on high) + `check:security`; uploads coverage to Codecov on the Node 20 matrix entry via repository secret `CODECOV_TOKEN`.
+- **CI** (`.github/workflows/ci.yml`): `test` job runs `npm test` (includes `check:security` — guard-test completeness + public API surface + npm pack gate) on Node 18/20/22; `security` job runs `npm audit --audit-level=high` (fails on high) + `check:security`; uploads coverage to Codecov on the Node 20 matrix entry via repository secret `CODECOV_TOKEN`.
 - **Auto-link** (`.github/workflows/auto-link-issue.yml`): prepends `Closes #N` when branch name starts with `N-`.
+- **Guard-test completeness**: `check:security` (in `npm test` and CI) runs [`scripts/check-guard-tests.mjs`](scripts/check-guard-tests.mjs), which fails closed if any guard script (`scripts/check-*.mjs`) lacks a matching unit-test spec (`test/check-*.spec.js`). This is a **structural** guarantee independent of line coverage — see [`docs/coverage-policy.md`](docs/coverage-policy.md). Coverage scope stays `src/**` only (`scripts/` is intentionally out of c8 scope; the completeness gate is the guarantee).
 - **Dead-code check**: the `security` job runs `npm run health:dead` (knip) **non-blocking** — an unused file/export is surfaced as a warning on PRs. The **hard** dead-code failure lives in [`publish.yml`](.github/workflows/publish.yml) (`npm run health:dead:strict`), so dead code cannot ship even though it does not block day-to-day integration merges. See [`knip.json`](knip.json).
 - **Publish** (`.github/workflows/publish.yml`): triggers on `v*.*.*` tags (and can also be run via `workflow_dispatch`); uses OIDC trusted publishing (no NPM_TOKEN needed); gated by the `npm` GitHub environment (requires manual approval).
 - Actions are SHA-pinned for supply-chain security; Dependabot (monthly, `github-actions` ecosystem) auto-bumps them.

--- a/docs/coverage-policy.md
+++ b/docs/coverage-policy.md
@@ -21,6 +21,19 @@ High coverage on language algorithms means fixture instances were exercised, not
 
 See [`.c8rc.json`](../.c8rc.json) — all four metrics at 90%. Interface-only files and barrel `index.ts` re-exports are excluded.
 
+### Coverage scope excludes `scripts/`
+
+`.c8rc.json` `include` is `src/**/*.ts` only — the CI guards under `scripts/` are **deliberately outside** line-coverage scope. Two reasons:
+
+1. A guard *executes* during `check:security` (part of `npm test`), so incidental execution would report it as "covered" even with no dedicated test — coverage cannot answer "does every guard have a real test?".
+2. The guards are `.mjs` run as subprocesses / side-effecting imports; measuring their lines would be noisy and would reward incidental execution over behavioral assertions — the opposite of this policy.
+
+Guard-test completeness is therefore enforced **structurally**, not by coverage: see below.
+
+## Guard-test completeness gate
+
+Every guard script (`scripts/check-*.mjs`) must ship a matching unit-test spec (`test/check-*.spec.js`). This is enforced fail-closed by [`scripts/check-guard-tests.mjs`](../scripts/check-guard-tests.mjs) (run via `check:security` in `npm test` and CI): adding a `check-*.mjs` without its spec fails CI. The gate is itself a `check-*.mjs` and so is subject to its own rule (it ships with [`test/check-guard-tests.spec.js`](../test/check-guard-tests.spec.js)). This closes the gap where [`check-public-api.mjs`](../scripts/check-public-api.mjs) shipped untested — structural, independent of line coverage.
+
 ## Exception process
 
 Only for genuinely unreachable defensive code:

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "health:dead": "knip",
     "health:dead:strict": "knip --production --strict",
     "check:package-scripts": "node scripts/check-package-scripts.mjs",
-    "check:security": "node scripts/check-public-api.mjs && node scripts/check-npm-pack.mjs",
+    "check:guard-tests": "node scripts/check-guard-tests.mjs",
+    "check:security": "node scripts/check-guard-tests.mjs && node scripts/check-public-api.mjs && node scripts/check-npm-pack.mjs",
     "git:reset": "git reset --hard HEAD && git clean -fd",
     "npm:reinstall": "node scripts/reinstall.js"
   },

--- a/scripts/check-guard-tests.mjs
+++ b/scripts/check-guard-tests.mjs
@@ -1,0 +1,81 @@
+/**
+ * CI gate: guard-test completeness.
+ *
+ * Every guard script (scripts/check-*.mjs) must have a matching unit-test spec
+ * (test/check-*.spec.js). This is a STRUCTURAL guarantee independent of line
+ * coverage: incidental execution of a guard during check:security can make it
+ * "covered" without a dedicated test proving its behavior. Fail-closed — an
+ * untested guard blocks CI.
+ *
+ * This guard is itself a check-*.mjs, so it is subject to its own rule and ships
+ * with test/check-guard-tests.spec.js.
+ */
+import { readdirSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __file = fileURLToPath(import.meta.url);
+const __dir = dirname(__file);
+const root = resolve(__dir, "..");
+
+const GUARD_PREFIX = "check-";
+const GUARD_SUFFIX = ".mjs";
+const SPEC_SUFFIX = ".spec.js";
+
+/**
+ * The stem of a guard script filename (e.g. "check-public-api.mjs" -> "check-public-api").
+ * Returns null for non-guard filenames.
+ */
+export function guardStem(filename) {
+  if (!filename.startsWith(GUARD_PREFIX) || !filename.endsWith(GUARD_SUFFIX)) {
+    return null;
+  }
+  return filename.slice(0, -GUARD_SUFFIX.length);
+}
+
+/**
+ * Given the list of files in scripts/ and test/, return the guard stems that
+ * lack a matching test/<stem>.spec.js. Pure — no filesystem access.
+ */
+export function findUntestedGuards(scriptFiles, testFiles) {
+  const specs = new Set(
+    testFiles.filter(f => f.endsWith(SPEC_SUFFIX)).map(f => f.slice(0, -SPEC_SUFFIX.length))
+  );
+  const missing = [];
+  for (const file of scriptFiles) {
+    const stem = guardStem(file);
+    if (stem === null) continue;
+    if (!specs.has(stem)) missing.push(stem);
+  }
+  return missing.sort();
+}
+
+export function runCheck({
+  scriptsDir = resolve(root, "scripts"),
+  testDir = resolve(root, "test"),
+  readDir = readdirSync,
+  log = msg => console.log(msg),
+  error = msg => console.error(msg),
+  exit = code => process.exit(code),
+} = {}) {
+  const scriptFiles = readDir(scriptsDir);
+  const testFiles = readDir(testDir);
+  const missing = findUntestedGuards(scriptFiles, testFiles);
+
+  if (missing.length === 0) {
+    const guardCount = scriptFiles.filter(f => guardStem(f) !== null).length;
+    log(`[check-guard-tests] OK — all ${guardCount} guard scripts have a matching spec`);
+    exit(0);
+    return;
+  }
+
+  error("[check-guard-tests] FAIL — guard scripts without a matching test/<name>.spec.js:");
+  for (const stem of missing) {
+    error(`  - scripts/${stem}.mjs  (add test/${stem}.spec.js)`);
+  }
+  exit(1);
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === __file) {
+  runCheck();
+}

--- a/scripts/check-package-scripts.mjs
+++ b/scripts/check-package-scripts.mjs
@@ -48,9 +48,15 @@ export function validatePackageJson(pkg) {
       expected: 'node scripts/check-package-scripts.mjs',
     },
     {
+      field: 'scripts["check:guard-tests"]',
+      actual: pkg?.scripts?.['check:guard-tests'],
+      expected: 'node scripts/check-guard-tests.mjs',
+    },
+    {
       field: 'scripts["check:security"]',
       actual: pkg?.scripts?.['check:security'],
-      expected: 'node scripts/check-public-api.mjs && node scripts/check-npm-pack.mjs',
+      expected:
+        'node scripts/check-guard-tests.mjs && node scripts/check-public-api.mjs && node scripts/check-npm-pack.mjs',
     },
     {
       field: 'scripts.prepublishOnly',

--- a/scripts/check-public-api.mjs
+++ b/scripts/check-public-api.mjs
@@ -6,15 +6,19 @@ import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
-const __dir = dirname(fileURLToPath(import.meta.url));
+const __file = fileURLToPath(import.meta.url);
+const __dir = dirname(__file);
 const root = resolve(__dir, "..");
 const require = createRequire(import.meta.url);
 
-const PUBLIC_EXPORTS = ["createFSA", "simulateFSA", "stepOnceFSA"];
-const DTS_EXPORT_PATTERN =
+export const PUBLIC_EXPORTS = ["createFSA", "simulateFSA", "stepOnceFSA"];
+export const DTS_EXPORT_PATTERN =
   /export\s*\{\s*type\s+TransitionInput\s*,\s*createFSA\s*,\s*simulateFSA\s*,\s*stepOnceFSA\s*\}\s*;/;
 
-function assertKeys(mod, label) {
+/**
+ * Throws unless `mod`'s own enumerable keys are exactly PUBLIC_EXPORTS.
+ */
+export function assertKeys(mod, label) {
   const keys = Object.keys(mod).sort();
   const expected = [...PUBLIC_EXPORTS].sort();
   if (JSON.stringify(keys) !== JSON.stringify(expected)) {
@@ -22,23 +26,40 @@ function assertKeys(mod, label) {
   }
 }
 
-const tsup = readFileSync(resolve(root, "tsup.config.ts"), "utf8");
-if (!tsup.includes('entry: { index: "src/modules.ts" }')) {
-  throw new Error('tsup index entry must be src/modules.ts');
+/**
+ * Throws unless tsup is configured to build both entries from src/modules.ts.
+ */
+export function assertTsupEntries(tsupSource) {
+  if (!tsupSource.includes('entry: { index: "src/modules.ts" }')) {
+    throw new Error('tsup index entry must be src/modules.ts');
+  }
+  if (!tsupSource.includes('entry: { bundle: "src/modules.ts" }')) {
+    throw new Error('tsup bundle entry must be src/modules.ts');
+  }
 }
-if (!tsup.includes('entry: { bundle: "src/modules.ts" }')) {
-  throw new Error('tsup bundle entry must be src/modules.ts');
+
+/**
+ * Throws unless the emitted lib/index.d.ts export line matches the contract.
+ */
+export function assertDtsExports(dtsSource) {
+  if (!DTS_EXPORT_PATTERN.test(dtsSource)) {
+    throw new Error("lib/index.d.ts exports do not match public API contract");
+  }
 }
 
-const dts = readFileSync(resolve(root, "lib/index.d.ts"), "utf8");
-if (!DTS_EXPORT_PATTERN.test(dts)) {
-  throw new Error("lib/index.d.ts exports do not match public API contract");
+export async function runCheck({ rootDir = root } = {}) {
+  assertTsupEntries(readFileSync(resolve(rootDir, "tsup.config.ts"), "utf8"));
+  assertDtsExports(readFileSync(resolve(rootDir, "lib/index.d.ts"), "utf8"));
+
+  const esm = await import(pathToFileURL(resolve(rootDir, "lib/index.js")).href);
+  assertKeys(esm, "lib/index.js");
+
+  const cjs = require(resolve(rootDir, "lib/index.cjs"));
+  assertKeys(cjs, "lib/index.cjs");
+
+  console.log("[check-public-api] OK — three-function public API on ESM, CJS, and index.d.ts");
 }
 
-const esm = await import(pathToFileURL(resolve(root, "lib/index.js")).href);
-assertKeys(esm, "lib/index.js");
-
-const cjs = require(resolve(root, "lib/index.cjs"));
-assertKeys(cjs, "lib/index.cjs");
-
-console.log("[check-public-api] OK — three-function public API on ESM, CJS, and index.d.ts");
+if (process.argv[1] && resolve(process.argv[1]) === __file) {
+  await runCheck();
+}

--- a/test/check-guard-tests.spec.js
+++ b/test/check-guard-tests.spec.js
@@ -1,0 +1,103 @@
+/**
+ * Unit tests for scripts/check-guard-tests.mjs (the guard-test completeness gate).
+ */
+import { assert } from "chai";
+import { guardStem, findUntestedGuards, runCheck } from "../scripts/check-guard-tests.mjs";
+
+describe("check-guard-tests", function () {
+  describe("guardStem", function () {
+    it("returns the stem for a guard script", function () {
+      assert.equal(guardStem("check-public-api.mjs"), "check-public-api");
+    });
+
+    it("returns null for a non-guard .mjs script", function () {
+      assert.isNull(guardStem("postbuild.mjs"));
+    });
+
+    it("returns null for a spec file", function () {
+      assert.isNull(guardStem("check-public-api.spec.js"));
+    });
+
+    it("returns null for a .js file that starts with check-", function () {
+      assert.isNull(guardStem("check-thing.js"));
+    });
+  });
+
+  describe("findUntestedGuards", function () {
+    it("returns empty when every guard has a matching spec", function () {
+      const scripts = ["check-a.mjs", "check-b.mjs", "postbuild.mjs"];
+      const tests = ["check-a.spec.js", "check-b.spec.js", "other.spec.js"];
+      assert.deepEqual(findUntestedGuards(scripts, tests), []);
+    });
+
+    it("flags a guard with no matching spec", function () {
+      const scripts = ["check-a.mjs", "check-b.mjs"];
+      const tests = ["check-a.spec.js"];
+      assert.deepEqual(findUntestedGuards(scripts, tests), ["check-b"]);
+    });
+
+    it("ignores non-guard scripts", function () {
+      const scripts = ["postbuild.mjs", "prebuild.mjs", "reinstall.js"];
+      assert.deepEqual(findUntestedGuards(scripts, []), []);
+    });
+
+    it("does not accept a .mjs spec (must be .spec.js)", function () {
+      const scripts = ["check-a.mjs"];
+      const tests = ["check-a.mjs"];
+      assert.deepEqual(findUntestedGuards(scripts, tests), ["check-a"]);
+    });
+
+    it("returns results sorted", function () {
+      const scripts = ["check-z.mjs", "check-a.mjs"];
+      assert.deepEqual(findUntestedGuards(scripts, []), ["check-a", "check-z"]);
+    });
+  });
+
+  describe("runCheck", function () {
+    function makeCapture() {
+      const logs = [];
+      const errors = [];
+      let exitCode = null;
+      return {
+        log: m => logs.push(m),
+        error: m => errors.push(m),
+        exit: c => { exitCode = c; },
+        get logs() { return logs; },
+        get errors() { return errors; },
+        get exitCode() { return exitCode; },
+      };
+    }
+
+    it("exits 0 when all guards are tested (injected dirs)", function () {
+      const cap = makeCapture();
+      runCheck({
+        readDir: dir =>
+          dir.endsWith("scripts") ? ["check-a.mjs", "postbuild.mjs"] : ["check-a.spec.js"],
+        log: cap.log,
+        error: cap.error,
+        exit: cap.exit,
+      });
+      assert.equal(cap.exitCode, 0);
+      assert.isTrue(cap.logs.some(l => l.includes("[check-guard-tests] OK")));
+    });
+
+    it("exits 1 and names the untested guard", function () {
+      const cap = makeCapture();
+      runCheck({
+        readDir: dir =>
+          dir.endsWith("scripts") ? ["check-a.mjs", "check-b.mjs"] : ["check-a.spec.js"],
+        log: cap.log,
+        error: cap.error,
+        exit: cap.exit,
+      });
+      assert.equal(cap.exitCode, 1);
+      assert.isTrue(cap.errors.some(e => e.includes("check-b")));
+    });
+
+    it("passes against the real scripts/ and test/ directories", function () {
+      const cap = makeCapture();
+      runCheck({ log: cap.log, error: cap.error, exit: cap.exit });
+      assert.equal(cap.exitCode, 0, cap.errors.join("\n"));
+    });
+  });
+});

--- a/test/check-package-scripts.spec.js
+++ b/test/check-package-scripts.spec.js
@@ -50,6 +50,12 @@ describe("check-package-scripts", function () {
     assert.isFalse(isPackageJsonValid(tampered));
   });
 
+  it("detects a tampered check:guard-tests script", function () {
+    const tampered = JSON.parse(JSON.stringify(REAL_PKG));
+    tampered.scripts["check:guard-tests"] = "echo ok";
+    assert.isFalse(isPackageJsonValid(tampered));
+  });
+
   it("detects a tampered prepublishOnly script", function () {
     const tampered = JSON.parse(JSON.stringify(REAL_PKG));
     tampered.scripts.prepublishOnly = "npm run build";

--- a/test/check-public-api.spec.js
+++ b/test/check-public-api.spec.js
@@ -1,0 +1,111 @@
+/**
+ * Unit tests for scripts/check-public-api.mjs.
+ * Exercises the pure contract-assertion helpers plus the real script end-to-end.
+ */
+import { assert } from "chai";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  PUBLIC_EXPORTS,
+  DTS_EXPORT_PATTERN,
+  assertKeys,
+  assertTsupEntries,
+  assertDtsExports,
+  runCheck,
+} from "../scripts/check-public-api.mjs";
+
+const __dir = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dir, "..");
+
+const VALID_DTS =
+  "export { type TransitionInput, createFSA, simulateFSA, stepOnceFSA };";
+const VALID_TSUP =
+  'export default defineConfig([\n  { entry: { index: "src/modules.ts" } },\n  { entry: { bundle: "src/modules.ts" } },\n]);';
+
+describe("check-public-api", function () {
+  describe("assertKeys", function () {
+    it("passes when the module exports exactly the public API", function () {
+      const mod = { createFSA: 1, simulateFSA: 2, stepOnceFSA: 3 };
+      assert.doesNotThrow(() => assertKeys(mod, "test-mod"));
+    });
+
+    it("passes regardless of key order", function () {
+      const mod = { stepOnceFSA: 1, createFSA: 2, simulateFSA: 3 };
+      assert.doesNotThrow(() => assertKeys(mod, "test-mod"));
+    });
+
+    it("throws when an extra export leaks", function () {
+      const mod = { createFSA: 1, simulateFSA: 2, stepOnceFSA: 3, internalThing: 4 };
+      assert.throws(() => assertKeys(mod, "leaky"), /leaky: expected/);
+    });
+
+    it("throws when a public export is missing", function () {
+      const mod = { createFSA: 1, simulateFSA: 2 };
+      assert.throws(() => assertKeys(mod, "partial"), /partial: expected/);
+    });
+
+    it("names the offending module in the error", function () {
+      assert.throws(() => assertKeys({}, "lib/index.cjs"), /lib\/index\.cjs/);
+    });
+  });
+
+  describe("assertTsupEntries", function () {
+    it("passes for a config building both entries from src/modules.ts", function () {
+      assert.doesNotThrow(() => assertTsupEntries(VALID_TSUP));
+    });
+
+    it("throws when the index entry is not src/modules.ts", function () {
+      const bad = VALID_TSUP.replace('index: "src/modules.ts"', 'index: "src/evil.ts"');
+      assert.throws(() => assertTsupEntries(bad), /index entry must be src\/modules\.ts/);
+    });
+
+    it("throws when the bundle entry is not src/modules.ts", function () {
+      const bad = VALID_TSUP.replace('bundle: "src/modules.ts"', 'bundle: "src/evil.ts"');
+      assert.throws(() => assertTsupEntries(bad), /bundle entry must be src\/modules\.ts/);
+    });
+  });
+
+  describe("assertDtsExports", function () {
+    it("passes for the contract export line", function () {
+      assert.doesNotThrow(() => assertDtsExports(VALID_DTS));
+    });
+
+    it("tolerates surrounding declarations", function () {
+      const dts = `declare function createFSA(): void;\n${VALID_DTS}\n`;
+      assert.doesNotThrow(() => assertDtsExports(dts));
+    });
+
+    it("throws when the export line is absent", function () {
+      assert.throws(
+        () => assertDtsExports("export { createFSA };"),
+        /do not match public API contract/
+      );
+    });
+
+    it("throws when an internal symbol is added to the export line", function () {
+      const bad = VALID_DTS.replace("stepOnceFSA }", "stepOnceFSA, NFA }");
+      assert.throws(() => assertDtsExports(bad), /do not match public API contract/);
+    });
+  });
+
+  describe("contract constants", function () {
+    it("PUBLIC_EXPORTS is exactly the three public functions", function () {
+      assert.deepEqual([...PUBLIC_EXPORTS].sort(), [
+        "createFSA",
+        "simulateFSA",
+        "stepOnceFSA",
+      ]);
+    });
+
+    it("DTS_EXPORT_PATTERN is a RegExp", function () {
+      assert.instanceOf(DTS_EXPORT_PATTERN, RegExp);
+    });
+  });
+
+  describe("runCheck (end-to-end)", function () {
+    it("passes against the real built lib artifacts", async function () {
+      // npm test builds lib/ before running mocha, so the artifacts exist here.
+      await runCheck({ rootDir: root });
+    });
+  });
+});


### PR DESCRIPTION
Part of the v1.9 release-hardening epic #306. Closes #310.

## What

- **`test/check-public-api.spec.js`** — the previously-untested guard now has a real spec. `check-public-api.mjs` is refactored into pure exported helpers (`assertKeys`, `assertTsupEntries`, `assertDtsExports`, `runCheck`) matching the pattern of the other guard scripts, plus an end-to-end run against the built `lib/`.
- **`scripts/check-guard-tests.mjs`** (+ `test/check-guard-tests.spec.js`) — a fail-closed **structural** completeness gate: every `scripts/check-*.mjs` must have a matching `test/check-*.spec.js`. Wired into `check:security` (so it runs in `npm test`, CI, and publish). The gate is itself a `check-*.mjs` and ships with its own spec.
- **Coverage-scope decision**: keep `.c8rc.json` `include` = `src/**` only. `scripts/` stays out of coverage because a guard *executes* during `check:security`, so line coverage can't answer "does every guard have a real test?" — the structural gate is the guarantee. Documented in `docs/coverage-policy.md`.
- Update the locked `check:security` expectation in `check-package-scripts.mjs` in lockstep; document in `AGENTS.md` + copilot mirror.

## Why

`check-public-api.mjs` shipped with no unit test, and nothing structural would have caught that. This makes guard-test completeness a gate rather than depending on a human noticing — the exact failure mode we can't afford going into v2.

## How tested

- `npm test` green (247 passing, up from 220; coverage 99% stmts / 90.3% branches).
- `check:guard-tests` exits 0 for the real tree; a temporary spec-less `check-probe.mjs` makes it exit 1 (verified).
- `npm run docs:lint` and `knip` clean.

## Expected red check

Touches protected files (`check-public-api.mjs`, `check-package-scripts.mjs`) → `lock-files` will be red. Expected staging-branch behavior per `AGENTS.md` §3; to be merged into the integration branch via admin. `check-guard-tests.mjs` is folded into the locked guard group by #276.

🤖 Generated with [Claude Code](https://claude.com/claude-code)