### PR TITLE
chore(release): bump version to 1.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fas-js",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fas-js",
-      "version": "1.8.0",
+      "version": "1.9.0",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "@eslint/js": "^9.39.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fas-js",
   "description": "Finate State Automata JS Solutions",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "type": "module",
   "main": "./lib/index.cjs",
   "module": "./lib/index.js",


### PR DESCRIPTION
Admin-initiated release bump (RELEASING.md §2) — the final change onto the integration branch before the release PR. Updates `package.json` + `package-lock.json` to 1.9.0.

Not protected → clean `lock-files`. Satisfies `verify-release-version` on the release PR (1.8.0 → 1.9.0).