### PR TITLE
chore: gitignore *.pem (App private key)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ lib/*
 demo/**/vendor/fas-js.bundle.js
 node_modules/
 coverage/
+# GitHub App private key (.pem) — never commit; provide via the APP_PRIVATE_KEY repo secret
+*.pem


### PR DESCRIPTION
Adds `*.pem` to `.gitignore` so a GitHub App private key can never be accidentally committed. The key itself belongs in the **`APP_PRIVATE_KEY` repo secret**, not the repo.

Demonstrates the now-PR-only integration flow (direct pushes can't satisfy the no-bypass `lock-files` ruleset). `.gitignore` is Open, so `lock-files` passes.